### PR TITLE
ui_gtk.py: bug fix in DB Editor, buffer_get_text

### DIFF
--- a/ui/ui_gtk.py
+++ b/ui/ui_gtk.py
@@ -911,7 +911,7 @@ class UI(UIBase):
             self.dbe_update()
             return
         if save:
-            p_data = (self.entry_dbe.get_text(), buffer_get_text(self.buffer_dbe.get_text))
+            p_data = (self.entry_dbe.get_text(), buffer_get_text(self.buffer_dbe))
         n = len(self.glosE.data)
         if 0 <= n_ind < n:
             pass


### PR DESCRIPTION
The function buffer_get_text expects the input value to be a buffer, not the get_text-method of some buffer.