### PR TITLE
important stability improvments

### DIFF
--- a/pyglossary/__init__.py
+++ b/pyglossary/__init__.py
@@ -1,0 +1,1 @@
+__version__ = VERSION = '2013.01.03'

--- a/pyglossary/glossary.py
+++ b/pyglossary/glossary.py
@@ -18,7 +18,7 @@
 ## with this program. Or on Debian systems, from /usr/share/common-licenses/GPL
 ## If not, see <http://www.gnu.org/licenses/gpl.txt>.
 
-VERSION = '2013.01.03'
+from . import VERSION
 
 homePage = 'http://github.com/ilius/pyglossary'
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ except ImportError:
 
 import glob, os, sys
 from os.path import join, dirname, exists, isdir
+import re
 
 from distutils.core import setup
 from distutils.command.install import install
@@ -126,6 +127,14 @@ setup(
     package_data = {
         'pyglossary': [
             'plugins/*.py',
+        ] + [
+            # safest way found so far to include every resource of plugins
+            # producing plugins/pkg/*, plugins/pkg/sub1/*, ... except .pyc/.pyo
+            re.sub(r'^.*?pyglossary%s(?=plugins)' % os.sep, '', join(dirpath, f))
+            for top in glob.glob(join(dirname(__file__), 'pyglossary', 'plugins'))
+            for dirpath, _, files in os.walk(top)
+            for f in files
+            if not (f.endswith('.pyc') or f.endswith('.pyo'))
         ],
     },
     data_files = data_files,


### PR DESCRIPTION
firstly, logging was fixed.  it was necessary to reorder some parts of code inside `pyglossary.pyw` to make logger initialize as early as possible.  there's descriptive comment on lines 33-44.  other code except logger was just moved but not modified.

in order to allow `glossary.py` use logging, version number had been moved to `__init__.py`, because it is needed when parsing arguments; and parsing arguments needed to set up logger's verbosity.

maybe it would be good idea to move logger initializing routine to separate module in the future.

secondly, `class Glossary`:
- plugins loading becomes clean, separate functions.
- safety improved (by the use of `if hasattr()` and try-catch blocks), so broken plugin would be reported but not lead to crash.
- debug and errors logging normally.
- using `pkgutil.iter_modules`, it's much cleaner than `endswith('.py')`, and allows loading from any type of python module/package (it's especially useful as in the next commit appledict plugin would become package).

finally, `setup.py` was rejecting to copy plugin's resources when latter was a package, but few lines of code @803fee3 have fixed that for good.