### PR TITLE
remove Glossary.uiEdit and thus `data` auto sorting

### DIFF
--- a/pyglossary/glossary.py
+++ b/pyglossary/glossary.py
@@ -987,11 +987,6 @@ class Glossary:
         return lines
 
 
-    def uiEdit(self):## remove? FIXME
-        p = self.ui.pref
-        if p['sort']:
-            self._data.sort()
-
     def getPref(self, name, default):
         if self.ui:
             return self.ui.pref.get(name, default)

--- a/ui/ui_cmd.py
+++ b/ui/ui_cmd.py
@@ -227,7 +227,6 @@ class UI(UIBase):
             return 1
         ## When glossary reader uses progressbar, progressbar must be rebuilded:
         self.progressBuild()
-        g.uiEdit()
         if reverse:
             log.info('Reversing to file "%s"'%opath)
             self.setText('')

--- a/ui/ui_gtk.py
+++ b/ui/ui_gtk.py
@@ -330,7 +330,6 @@ class UI(UIBase):
         #self.iFormat = format
         self.iPath = iPath
         self.button_conv.set_sensitive(True)
-        self.glos.uiEdit()
         self.progress(1.0, 'Loading Comleted')
         log.debug('time left = %3f seconds'%(time.time()-t0))
         for x in self.glos.info:
@@ -354,7 +353,6 @@ class UI(UIBase):
             self.ptext = ' of file %s from %s files'%(i+1, n)
             log.info('Loading "%s" ...'%path)
             g.read(path)
-            g.uiEdit()
             log.info('%s words found'%len(g.data))
             if mode==0:
                 self.glos = self.glos.attach(g)
@@ -566,8 +564,6 @@ class UI(UIBase):
         log.debug('time left = %3f seconds'%(time.time()-t0))
         for x in self.glos.info:
             log.info('%s="%s"'%(x[0], x[1]))
-        #self.glosR.faEdit()
-        self.glosR.uiEdit()
         #self.riFormat = format
         #self.riPath = iPath
         log.info('reading %s file: "%s" done.\n%d words found.'%(
@@ -794,7 +790,6 @@ class UI(UIBase):
             format = Glossary.descFormat[self.fcd_format]
             self.glosE.read(self.dbe_path, format=format, **read_options)
         self.assert_quit = True
-        self.glosE.uiEdit()
         log.debug('time left = %3f seconds'%(time.time()-t0))
         for x in self.glos.info:
             log.info('%s="%s"'%(x[0], x[1]))

--- a/ui/ui_gtk_new.py
+++ b/ui/ui_gtk_new.py
@@ -428,7 +428,6 @@ class UI(gtk.Dialog, UIBase):
                 return False
             #self.inFormat = inFormat
             #self.inPath = inPath
-            self.glos.uiEdit()
             #self.progress(1.0, 'Loading Comleted')
             log.debug('running time of read: %3f seconds'%(time.time()-t0))
             for x in self.glos.info:

--- a/ui/ui_tk.py
+++ b/ui/ui_tk.py
@@ -738,7 +738,6 @@ class UI(Tix.Frame, UIBase):
         #self.iFormat = format
         self.iPath = iPath
         #self.button_conv.set_sensitive(True)
-        self.glos.uiEdit()
         self.progress(1.0, 'Loading Comleted')
         log.info('time left = %3f seconds'%(time.time()-t0))
         for x in self.glos.info:


### PR DESCRIPTION
okay, while we are still friends, tell me, why did you do that.  you have five seconds to answer before i pull the trigger. ohh, by the way… the gun is aimed at my leg, not even at you.

now really. i have no idea what the method with strange name `uiEdit` was for, but all it was doing is unconditionally sorting the `data`.  i found no way to change this behaviour but to edit the code.

some formats may require sorting entries, others don't.

my purpose was to load some `.dsl` file, parse it and recover broken markup, save it and finally compare with `diff`.  auto sorting was really standing in my way.