### PR TITLE
appledict: fix dropping entries with one-letter title

### DIFF
--- a/pyglossary/plugins/appledict/_normalize.py
+++ b/pyglossary/plugins/appledict/_normalize.py
@@ -94,7 +94,8 @@ def title(title, BeautifulSoup):
     """strip double quotes and html tags."""
     if BeautifulSoup:
         title = title.replace('\xef\xbb\xbf', '')
-        title = BeautifulSoup.BeautifulSoup(title, "html").get_text(strip=True).encode('utf-8')
+        if len(title) > 1:  # BeautifulSoup has a bug when markup <= 1 char length
+            title = BeautifulSoup.BeautifulSoup(title, "html").get_text(strip=True).encode('utf-8')
     else:
         title = _title_re.sub('', title)
         title = title.replace('&', '&amp;')


### PR DESCRIPTION
it's actually a bug of `BeautifulSoup + lxml`.  no other combinations appear to have same strange behaviour.