### PR TITLE
change Categories for pyglossary.desktop

### DIFF
--- a/pyglossary.desktop
+++ b/pyglossary.desktop
@@ -8,5 +8,5 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Icon=pyglossary
-Categories=utility;
+Categories=Education;
 X-GNOME-FullName=Glossary Converter

--- a/pyglossary.spec
+++ b/pyglossary.spec
@@ -15,7 +15,7 @@ BuildArch:      noarch
 
 %description
 Working on glossaries (dictionary databases) using python. Including editing
-glossarys and converting theme between many formats such as: Tabfile StarDict
+glossaries and converting theme between many formats such as: Tabfile StarDict
 format xFarDic format "Babylon Builder" source format Omnidic format and etc.
 
 %prep


### PR DESCRIPTION
@ilius, I guess _Education_ is a more consistent value for the category.