### PR TITLE
Fix filenames without .ifo ending for startdict export

### DIFF
--- a/pyglossary/plugins/stardict.py
+++ b/pyglossary/plugins/stardict.py
@@ -415,7 +415,7 @@ class Writer(object):
 		dictzip: bool = True,
 		sametypesequence: str = "", # type: Literal["", "h", "m"]
 	) -> None:
-		fileBasePath = ""
+		fileBasePath = filename
 		##
 		if splitext(filename)[1].lower() == ".ifo":
 			fileBasePath = splitext(filename)[0]


### PR DESCRIPTION
Export to startdict with filename not ending on .ifo resulted in
writing hidden files .ifo, .idx and .dict.