### PR TITLE
Moving dictionary development kit to home

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ you also need:
 	Xcode](http://developer.apple.com/downloads).
 -	Dictionary Development Kit as part of [Additional Tools for
 	Xcode](http://developer.apple.com/downloads). Extract to
-	`/Developer/Extras/Dictionary Development Kit`
+	`~/Developer/Extras/Dictionary Development Kit`
 
 
 HOWTOs

--- a/pyglossary/plugins/appledict/templates/Makefile
+++ b/pyglossary/plugins/appledict/templates/Makefile
@@ -22,7 +22,7 @@ DICT_BUILD_OPTS		=
 # The DICT_BUILD_TOOL_DIR value is used also in "build_dict.sh" script.
 # You need to set it when you invoke the script directly.
 
-DICT_BUILD_TOOL_DIR	=	"/Developer/Extras/Dictionary Development Kit"
+DICT_BUILD_TOOL_DIR	=	"$(HOME)/Developer/Extras/Dictionary Development Kit"
 DICT_BUILD_TOOL_BIN	=	"$(DICT_BUILD_TOOL_DIR)/bin"
 
 ###########################


### PR DESCRIPTION
The root may not be writable on newer Mac. Changing the README and Makefile to put dictionary development kit under `$HOME`