### PR TITLE
Improve on parsing and rendering of dictd format

### DIFF
--- a/pyglossary/plugins/dict_org.py
+++ b/pyglossary/plugins/dict_org.py
@@ -112,9 +112,10 @@ class Reader(object):
 			raise RuntimeError("iterating over a reader while it's not open")
 		dictdb = self._dictdb
 		for word in dictdb.getdeflist():
-			b_defi = b"\n<hr>\n".join(dictdb.getdef(word))
+			b_defi = b"\n\n--------\n\n".join(dictdb.getdef(word))
 			try:
-				defi = b_defi.decode("utf_8")
+				b_defi = b_defi.replace(b"\n\n", b"\n \n")
+				defi = b_defi.decode("utf_8", 'ignore')
 			except Exception as e:
 				log.error(f"b_defi = {b_defi}")
 				raise e

--- a/pyglossary/plugins/dict_org.py
+++ b/pyglossary/plugins/dict_org.py
@@ -88,10 +88,10 @@ class Reader(object):
 		self._glos = glos
 		self._filename = ""
 		self._dictdb = None  # type: Optional[DictDB]
-
-                # regular expression patterns used to prettify 
-                # definition text
-		self.compilePatterns()
+		
+		# regular expression patterns used to prettify definition text
+		self._re_newline_in_braces = re.compile(r'\{(?P<left>.*?)\n(?P<right>.*?)?\}')
+		self._re_words_in_braces = re.compile(r'\{(?P<word>.+?)\}')
 
 	def open(self, filename: str) -> None:
 		import gzip
@@ -107,20 +107,16 @@ class Reader(object):
 			# self._dictdb.finish()
 			self._dictdb = None
 
-	def compilePatterns(self) -> None:
-		self._re_newline_in_braces = re.compile(r'\{(?P<left>.*?)\n(?P<right>.*?)?\}')
-		self._re_words_in_braces = re.compile(r'\{(?P<word>.+?)\}')
-
 	def prettifyDefinitionText(self, defi: str) -> str:
-                # Handle words in {}. 
-                # First, we remove any \n in {} pairs
+		# Handle words in {}. 
+		# First, we remove any \n in {} pairs
 		defi = self._re_newline_in_braces.sub(r'{\g<left>\g<right>}', defi)
 
-                # Then, replace any {words} into <a href="words">words</a>,
-                # so it can be rendered as link correctly
-		defi = self._re_words_in_braces.sub(r'<a href="\g<word>">\g<word></a>', defi)
+		# Then, replace any {words} into <a href="bword://words">words</a>,
+		# so it can be rendered as link correctly
+		defi = self._re_words_in_braces.sub(r'<a href="bword://\g<word>">\g<word></a>', defi)
 
-                 # Use <br /> so it can be rendered as newline correctly
+		# Use <br /> so it can be rendered as newline correctly
 		defi = defi.replace("\n", "<br />")
 		return defi
 

--- a/pyglossary/plugins/dict_org.py
+++ b/pyglossary/plugins/dict_org.py
@@ -112,9 +112,9 @@ class Reader(object):
 			raise RuntimeError("iterating over a reader while it's not open")
 		dictdb = self._dictdb
 		for word in dictdb.getdeflist():
-			b_defi = b"\n\n--------\n\n".join(dictdb.getdef(word))
+			b_defi = b"\n\n<hr>\n\n".join(dictdb.getdef(word))
 			try:
-				b_defi = b_defi.replace(b"\n\n", b"\n \n")
+				b_defi = b_defi.replace(b"\n", b"<br />")
 				defi = b_defi.decode("utf_8", 'ignore')
 			except Exception as e:
 				log.error(f"b_defi = {b_defi}")


### PR DESCRIPTION
Hi,

This is a simple patch to make dictd contents look a bit well-formatted after parsing. The following are what I do in this PR:

1. Fix web link, so that any words with {} around will be rendered as `<a href=...>` link.
2. Replace newline with `<br />`.

Here are two screenshots (where I converted a dictd index file to aard slob). The first one is the original version, and the second one is my "patched" version:
![image](https://user-images.githubusercontent.com/1317617/108744945-7e913100-7575-11eb-8556-64de762c251b.png)
![image](https://user-images.githubusercontent.com/1317617/108745042-9a94d280-7575-11eb-93fe-69ef9fbd891d.png)

It looks better after applying my patch:)