### PR TITLE
Fix incorrect venv directory detection

### DIFF
--- a/pyglossary/core.py
+++ b/pyglossary/core.py
@@ -245,6 +245,9 @@ if dataDir.endswith("dist-packages") or dataDir.endswith("site-packages"):
 		if not isdir(dataDir):
 			pyVer = f'{sys.version_info.major}{sys.version_info.minor}'
 			dataDir = join(parent3, f"Python{pyVer}", "share", "pyglossary")
+		if not isdir(dataDir):
+			venv_dir = os.environ['VIRTUAL_ENV']
+			dataDir = join(parent3, venv_dir, "share", "pyglossary")
 	else:
 		dataDir = join(parent3, "share", "pyglossary")
 


### PR DESCRIPTION
Hello! 👋

The issue https://github.com/ilius/pyglossary/issues/307 hasn't been fixed properly.
The current code assumes pyglossary is always installed in "Python"/"Python{version}" directory ignoring cases when virtual env with custom directory name is used. For example, when I use [poetry](https://github.com/python-poetry/poetry), the directory is `c:\Users\germn\AppData\Local\pypoetry\Cache\virtualenvs\project-name-OPZUfFNv-py3.9\`.

This directory [can be fetched](https://stackoverflow.com/a/22004069/1113207) from `VIRTUAL_ENV` environment variable.
The PR adds a short fix for the case.
Note, that there's can be more convenient/proper way to do this, I didn't dig deep.