### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/octopus_mdict/README.rst
+++ b/doc/octopus_mdict/README.rst
@@ -52,7 +52,7 @@ Read MDX file and print the first entry::
     Out[4]:
     ('A',
      '<span style=\'display:block;color:black;\'>.........')
-``mdx`` is an objectt having all info from a MDX file. ``items`` is an iterator producing 2-item tuples.
+``mdx`` is an object having all info from a MDX file. ``items`` is an iterator producing 2-item tuples.
 Of each tuple, the first element is the entry text and the second is the explanation. Both are UTF-8 encoded strings.
 
 Read MDD file and print the first entry::

--- a/pyglossary/html_utils.py
+++ b/pyglossary/html_utils.py
@@ -361,7 +361,7 @@ def _sub_unescape_unicode(m: "re.Match") -> str:
 def unescape_unicode(text):
 	"""
 		unscape unicode entities, but not "&lt;", "&gt;" and "&amp;"
-		leave these 3 special entities alone, since unscaping them
+		leave these 3 special entities alone, since unescaping them
 		creates invalid html
 		we also ignore quotations: "&quot;" and "&#x27;"
 	"""

--- a/pyglossary/plugins/dsl/__init__.py
+++ b/pyglossary/plugins/dsl/__init__.py
@@ -424,7 +424,7 @@ class Reader(object):
 				line_type = "text"
 				line = unfinished_line + line.lstrip()
 
-				# some ill formated source may have tags spanned into
+				# some ill formatted source may have tags spanned into
 				# multiple lines
 				# try to match opening and closing tags
 				tags_open = re_tags_open.findall(line)
@@ -450,7 +450,7 @@ class Reader(object):
 			# append previous entry
 			if line_type == "text":
 				if unfinished_line:
-					# line may be skipped if ill formated
+					# line may be skipped if ill formatted
 					current_text.append(self.clean_tags(unfinished_line, self._audio))
 				yield self._glos.newEntry(
 					[current_key] + current_key_alters,

--- a/pyglossary/plugins/dsl/main.py
+++ b/pyglossary/plugins/dsl/main.py
@@ -268,7 +268,7 @@ class DSLParser(object):
 				else:
 					clean_line += BRACKET_L + chunk.replace("[", BRACKET_L)\
 						.replace("]", BRACKET_R)
-			else:  # firsr chunk
+			else:  # first chunk
 				clean_line += chunk.replace("[", BRACKET_L)\
 					.replace("]", BRACKET_R)
 		return clean_line

--- a/pyglossary/plugins/jmdict.py
+++ b/pyglossary/plugins/jmdict.py
@@ -189,7 +189,7 @@ class Reader(object):
 				# this is for making internal links valid
 				# this makes too many alternates!
 				# but we don't seem to have a choice
-				# execpt for scanning and indexing all words once
+				# except for scanning and indexing all words once
 				# and then starting over and fixing/optimizing links
 				for keb in kebList:
 					for reb, _ in rebList:

--- a/pyglossary/plugins/octopus_mdict_new/__init__.py
+++ b/pyglossary/plugins/octopus_mdict_new/__init__.py
@@ -67,7 +67,7 @@ class Reader(object):
 		self._wordCount = 0
 		self._dataEntryCount = 0
 
-		# dict of mainWord -> newline-separated altenatives
+		# dict of mainWord -> newline-separated alternatives
 		self._linksDict = {}  # type: Dict[str, str]
 
 	def open(self, filename):

--- a/pyglossary/ui/main.py
+++ b/pyglossary/ui/main.py
@@ -375,7 +375,7 @@ def main():
 		core.StdLogHandler(noColor=args.noColor),
 	)
 	# with the logger setted up, we can import other pyglossary modules, so they
-	# can do some loggging in right way.
+	# can do some logging in right way.
 
 	core.checkCreateConfDir()
 

--- a/pyglossary/ui/ui_cmd_interactive.py
+++ b/pyglossary/ui/ui_cmd_interactive.py
@@ -31,7 +31,7 @@ from collections import OrderedDict
 
 import json
 
-# the code for cmd.Cmd is very ugly and hard to understan
+# the code for cmd.Cmd is very ugly and hard to understand
 
 # readline's complete func silently (and stupidly) hides any exception
 # and only shows the print if it's in the first line of function. very awkward!

--- a/pyglossary/ui/ui_gtk.py
+++ b/pyglossary/ui/ui_gtk.py
@@ -1134,7 +1134,7 @@ class UI(gtk.Dialog, MyDialog, UIBase):
 		# gtk.main_quit()
 		# if callled while converting, main_quit does not exit program,
 		# it keeps printing warnings,
-		# and makes you close the terminal or force kill the proccess
+		# and makes you close the terminal or force kill the process
 		sys.exit(0)
 
 	def consoleClearButtonClicked(self, widget=None):


### PR DESCRIPTION
There are small typos in:
- doc/octopus_mdict/README.rst
- pyglossary/html_utils.py
- pyglossary/plugins/dsl/__init__.py
- pyglossary/plugins/dsl/main.py
- pyglossary/plugins/jmdict.py
- pyglossary/plugins/octopus_mdict_new/__init__.py
- pyglossary/ui/main.py
- pyglossary/ui/ui_cmd_interactive.py
- pyglossary/ui/ui_gtk.py

Fixes:
- Should read `unescaping` rather than `unscaping`.
- Should read `formatted` rather than `formated`.
- Should read `understand` rather than `understan`.
- Should read `process` rather than `proccess`.
- Should read `object` rather than `objectt`.
- Should read `logging` rather than `loggging`.
- Should read `first` rather than `firsr`.
- Should read `except` rather than `execpt`.
- Should read `alternatives` rather than `altenatives`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md