### PR TITLE
Fix #351 - working epub and mobi destinations

### DIFF
--- a/pyglossary/ebook_base.py
+++ b/pyglossary/ebook_base.py
@@ -216,9 +216,9 @@ class EbookWriter(object):
 			return "SPECIAL"
 		return prefix
 
-	def sortKey(self, b_word: bytes) -> "Any":
+	def sortKey(self, words: "List[str]") -> "Any":
 		# DO NOT change method name
-		word = b_word.decode("utf-8")
+		word = words[0]
 		return (
 			self.get_prefix(word),
 			word,


### PR DESCRIPTION
Function sortKey() was consistently being called with a list of strings. The method had been expecting a single byte-array