### PR TITLE
Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/pyglossary/plugin_lib/readmdict.py
+++ b/pyglossary/plugin_lib/readmdict.py
@@ -136,7 +136,7 @@ class MDict(object):
 		"""
 		extract attributes from <Dict attr="value" ... >
 		"""
-		taglist = re.findall(b'(\w+)="(.*?)"', header, re.DOTALL)
+		taglist = re.findall(rb'(\w+)="(.*?)"', header, re.DOTALL)
 		tagdict = {}
 		for key, value in taglist:
 			tagdict[key] = _unescape_entities(value)
@@ -523,8 +523,8 @@ class MDX(MDict):
 
 	def _substitute_stylesheet(self, txt):
 		# substitute stylesheet definition
-		txt_list = re.split('`\d+`', txt)
-		txt_tag = re.findall('`\d+`', txt)
+		txt_list = re.split(r'`\d+`', txt)
+		txt_tag = re.findall(r'`\d+`', txt)
 		txt_styled = txt_list[0]
 		for j, p in enumerate(txt_list[1:]):
 			key = txt_tag[j][1:-1]

--- a/pyglossary/text_utils.py
+++ b/pyglossary/text_utils.py
@@ -98,7 +98,7 @@ def splitByBarUnescapeNTB(st: str) -> "List[str]":
 
 
 def escapeBar(st: str) -> str:
-	"""
+	r"""
 		scapes vertical bar (\|)
 	"""
 	st = st.replace("\\", "\\\\")
@@ -107,7 +107,7 @@ def escapeBar(st: str) -> str:
 
 
 def unescapeBar(st: str) -> str:
-	"""
+	r"""
 		unscapes vertical bar (\|)
 	"""
 	st = pattern_bar_us.sub(r"\1|", st)
@@ -134,7 +134,7 @@ def joinByBar(parts: "List[str]") -> "str":
 
 
 def unescapeBarBytes(st: bytes) -> bytes:
-	"""
+	r"""
 		unscapes vertical bar (\|)
 	"""
 	st = b_pattern_bar_us.sub(b"\\1|", st)


### PR DESCRIPTION
To prevent such warnings:

```python
pyglossary/plugin_lib/readmdict.py:139: DeprecationWarning: invalid escape sequence '\w'
  taglist = re.findall(b'(\w+)="(.*?)"', header, re.DOTALL)
pyglossary/plugin_lib/readmdict.py:526: DeprecationWarning: invalid escape sequence '\d'
  txt_list = re.split('`\d+`', txt)
pyglossary/text_utils.py:101: DeprecationWarning: invalid escape sequence '\|'
  """
```