### PR TITLE
add mobi7-forcing switch to kindlegen command

### DIFF
--- a/pyglossary/plugins/ebook_mobi.py
+++ b/pyglossary/plugins/ebook_mobi.py
@@ -335,7 +335,7 @@ xmlns:oebpackage="http://openebook.org/namespaces/oeb-package/1.0/">
 		log.info(f"Creating .mobi file with kindlegen, using {kindlegen_path!r}")
 		opf_path_abs = join(filename, "OEBPS", "content.opf")
 		proc = subprocess.Popen(
-			[kindlegen_path, opf_path_abs, "-o", "content.mobi"],
+			[kindlegen_path, opf_path_abs, "-gen_ff_mobi7", "-o", "content.mobi"],
 			stdout=subprocess.PIPE,
 			stdin=subprocess.PIPE,
 			stderr=subprocess.PIPE


### PR DESCRIPTION
This will speed up conversion to mobi by skipping kindlegen's attempts to create an enhanced mobi (KF8), because Kindle dictionaries cannot be made in the KF8 format anyway. Kindlegen does automatically detect that it must create a mobi7 file, but not until after it's parsed some number of the source xhtml files listed in content.opf. This commit tells kindlegen to make a mobi7 file from the start.