### PR TITLE
ui_gtk: Fix getWorkAreaSize on Wayland

### DIFF
--- a/pyglossary/ui/ui_gtk.py
+++ b/pyglossary/ui/ui_gtk.py
@@ -84,7 +84,8 @@ def getScreenSize():
 
 def getWorkAreaSize():
 	display = gdk.Display.get_default()
-	monitor = display.get_primary_monitor()
+	rootWindow = gdk.get_default_root_window()
+	monitor = display.get_monitor_at_window(rootWindow)
 	rect = monitor.get_workarea()
 	return rect.width, rect.height
 


### PR DESCRIPTION
Based on https://discourse.gnome.org/t/get-screen-width-and-height/7245/13

Tested on Debian 11 (bullseye) with GNOME 3 Wayland. It should work on X11 too but I didn't test it.

Under my light usage, I didn't find anything else in the UI that needed changes under Wayland.