### PR TITLE
MDict: fix files created without UUID in header

### DIFF
--- a/pyglossary/plugin_lib/readmdict.py
+++ b/pyglossary/plugin_lib/readmdict.py
@@ -106,17 +106,18 @@ class MDict(object):
 			if isinstance(userid, unicode):
 				userid = userid.encode('utf8')
 			self._encrypted_key = _decrypt_regcode_by_userid(regcode, userid)
-		# MDict 3.0 encryption key derives from UUID
+		# MDict 3.0 encryption key derives from UUID if present
 		elif self._version >= 3.0:
-			if xxhash is None:
-				raise RuntimeError(
-					"xxhash module is needed to read MDict 3.0 format"
-					"\n"
-					"Run `pip3 install xxhash` to install"
-				)
-			uuid = self.header[b'UUID']
-			mid = (len(uuid) + 1) // 2
-			self._encrypted_key = xxhash.xxh64_digest(uuid[:mid]) + xxhash.xxh64_digest(uuid[mid:])
+			uuid = self.header.get(b'UUID')
+			if uuid:
+				if xxhash is None:
+					raise RuntimeError(
+						"xxhash module is needed to read MDict 3.0 format"
+						"\n"
+						"Run `pip3 install xxhash` to install"
+					)
+				mid = (len(uuid) + 1) // 2
+				self._encrypted_key = xxhash.xxh64_digest(uuid[:mid]) + xxhash.xxh64_digest(uuid[mid:])
 
 		self._key_list = self._read_keys()
 


### PR DESCRIPTION
See comment https://github.com/ilius/pyglossary/pull/385#issuecomment-1253912058. MdxBuilder 4.0 RC2 and before creates files without UUID header. The encryption key derives from each data blocks's alder32 checksum.