### PR TITLE
Fix typos

### DIFF
--- a/doc/p/aard2_slob.md
+++ b/doc/p/aard2_slob.md
@@ -25,7 +25,7 @@
 | content_type        |         | str  | Content Type                                                    |
 | file_size_approx    | `0`     | int  | split up by given approximate file size<br />examples: 100m, 1g |
 | separate_alternates | `False` | bool | add alternate headwords as separate entries to slob             |
-| word_title          | `False` | bool | add headwords title to begining of definition                   |
+| word_title          | `False` | bool | add headwords title to beginning of definition                   |
 
 ### Dependencies for reading and writing
 

--- a/doc/p/babylon_bgl.md
+++ b/doc/p/babylon_bgl.md
@@ -26,7 +26,7 @@
 | target_encoding_overwrite   |          | str  | Target encoding (overwrite)                 |
 | part_of_speech_color        | `007000` | str  | Color for Part of Speech                    |
 | no_control_sequence_in_defi | `False`  | bool | No control sequence in definitions          |
-| strict_string_convertion    | `False`  | bool | Strict string convertion                    |
+| strict_string_conversion    | `False`  | bool | Strict string conversion                    |
 | process_html_in_key         | `False`  | bool | Process HTML in (entry or info) key         |
 | key_rstrip_chars            |          | str  | Characters to strip from right-side of keys |
 

--- a/doc/p/csv.md
+++ b/doc/p/csv.md
@@ -33,7 +33,7 @@
 | delimiter       | `,`     | str  | Column delimiter                              |
 | add_defi_format | `False` | bool | enable adding defiFormat (m/h/x)              |
 | enable_info     | `True`  | bool | Enable glossary info / metedata               |
-| word_title      | `False` | bool | add headwords title to begining of definition |
+| word_title      | `False` | bool | add headwords title to beginning of definition |
 
 
 

--- a/doc/p/dikt_json.md
+++ b/doc/p/dikt_json.md
@@ -24,7 +24,7 @@
 | encoding    | `utf-8` | str  | Encoding/charset                              |
 | enable_info | `True`  | bool | Enable glossary info / metedata               |
 | resources   | `True`  | bool | Enable resources / data files                 |
-| word_title  | `False` | bool | add headwords title to begining of definition |
+| word_title  | `False` | bool | add headwords title to beginning of definition |
 
 
 

--- a/doc/p/freedict.md
+++ b/doc/p/freedict.md
@@ -23,7 +23,7 @@
 | --------------- | ------- | ---- | --------------------------------------------- |
 | discover        | `False` | bool | Find and show unsupported tags                |
 | auto_rtl        | `None`  | bool | Auto-detect and mark Right-to-Left text       |
-| word_title      | `False` | bool | Add headwords title to begining of definition |
+| word_title      | `False` | bool | Add headwords title to beginning of definition |
 | pron_color      | `gray`  | str  | Pronunciation color                           |
 | gram_color      | `green` | str  | Grammar color                                 |
 | example_padding | `10`    | int  | Padding for examples (in px)                  |

--- a/doc/p/html_dir.md
+++ b/doc/p/html_dir.md
@@ -28,7 +28,7 @@
 | escape_defi     | `False`        | bool | Escape definitions                            |
 | dark            | `True`         | bool | Use dark style                                |
 | css             |                | str  | Path to css file                              |
-| word_title      | `True`         | bool | Add headwords title to begining of definition |
+| word_title      | `True`         | bool | Add headwords title to beginning of definition |
 
 
 ### Dependencies for writing

--- a/doc/p/json.md
+++ b/doc/p/json.md
@@ -24,7 +24,7 @@
 | encoding    | `utf-8` | str  | Encoding/charset                              |
 | enable_info | `True`  | bool | Enable glossary info / metedata               |
 | resources   | `True`  | bool | Enable resources / data files                 |
-| word_title  | `False` | bool | add headwords title to begining of definition |
+| word_title  | `False` | bool | add headwords title to beginning of definition |
 
 
 

--- a/doc/p/tabfile.md
+++ b/doc/p/tabfile.md
@@ -31,7 +31,7 @@
 | enable_info      | `True`  | bool | Enable glossary info / metedata                                 |
 | resources        | `True`  | bool | Enable resources / data files                                   |
 | file_size_approx | `0`     | int  | Split up by given approximate file size<br />examples: 100m, 1g |
-| word_title       | `False` | bool | Add headwords title to begining of definition                   |
+| word_title       | `False` | bool | Add headwords title to beginning of definition                   |
 
 
 

--- a/doc/releases/3.0.4.md
+++ b/doc/releases/3.0.4.md
@@ -24,7 +24,7 @@
     -   Sdictionary Source (sdct)
 -   Feature in Lingoes Source plugin: add `newline` write option
 -   Minor fix in AppleDict plugin: fix beautifulsoup4 error message, [#72](https://github.com/ilius/pyglossary/issues/72)
--   BGL plugin: better compatibilty with Python 3.4
+-   BGL plugin: better compatibility with Python 3.4
     Fix `CRC check failed` error for some (rare) glossaries with Python 3.4
 
 ## Other Changes ##

--- a/doc/releases/3.2.0.md
+++ b/doc/releases/3.2.0.md
@@ -8,7 +8,7 @@
 	* Fix [#137](https://github.com/ilius/pyglossary/issues/137), regexp for re_lang_open
 
 - Improvement in Gtk interface:
-	* Avoid changing Format combobox based on file extention if a format is already selected, [#141](https://github.com/ilius/pyglossary/issues/141)
+	* Avoid changing Format combobox based on file extension if a format is already selected, [#141](https://github.com/ilius/pyglossary/issues/141)
 
 - Fix encoding problem with non-UTF-8 system locales
 	* Fix [#147](https://github.com/ilius/pyglossary/issues/147), give encoding="utf-8" when opening text files, for non-UTF-8 system locales

--- a/doc/releases/3.3.0.md
+++ b/doc/releases/3.3.0.md
@@ -1,6 +1,6 @@
 # Changes since [3.2.1](./3.2.1.md) #
 
-- Require Python 3.6 or higher (mainly becuase of f-strings)
+- Require Python 3.6 or higher (mainly because of f-strings)
 
 - New format support
 	- Add support to write Kobo dictionary, [#205](https://github.com/ilius/pyglossary/issues/205)
@@ -55,7 +55,7 @@
 
 - StarDict plugin
 	- Always open `.ifo` file as UTF-8
-	- Fix output filenames without .ifo extention creating hidden files, [#187](https://github.com/ilius/pyglossary/issues/187)
+	- Fix output filenames without .ifo extension creating hidden files, [#187](https://github.com/ilius/pyglossary/issues/187)
 
 - Babylon BGL plugin
 	- Fix bytes metedata values `b'...'` and some refactoring in readType3
@@ -79,7 +79,7 @@
 	- Use keyword argument `features=` and fix a warning about from_encoding=
 
 
-- Fix misspelled "extension" (as "extention") in plugins
+- Fix misspelled "extension" (as "extension") in plugins
 - Detect entries with `span` tag as html, [#193](https://github.com/ilius/pyglossary/issues/193)
 - Refactoring in ui_gtk and ui_tk
 - Fix some deprecated API in ui_gtk

--- a/doc/releases/4.0.0.md
+++ b/doc/releases/4.0.0.md
@@ -3,13 +3,13 @@
 - Require Python 3.7 or 3.8, drop support for Python 3.4, 3.5 and 3.6
 
 - Fix / rewrite `setup.py`
-	- Fix `python3 setup.py sdist bdist_wheel`, and pypi paackage
+	- Fix `python3 setup.py sdist bdist_wheel`, and pypi package
 		- Had to move `ui/` directory into `pyglossary/`
 	- Switch from `distutils` to `setuptools`
 	- Remove `py2exe`
 
 - Add interactive command line user interface
-	- Automatically selected if input & ouput file arguments are not passed **and** one of these:
+	- Automatically selected if input & output file arguments are not passed **and** one of these:
 		- On Linux and no `$DISPLAY` is not set
 		- On Mac and no `tkinter` module is found
 		- `--ui=cmd` flag is passed
@@ -42,7 +42,7 @@
 - XDXF Reader: rewrite with `etree.iterparse` to avoid using too much RAM
 - Lingoes Source (LDF) Reader: fix ignoring info/metadata header
 - dict_org.py: rewrite broken plugin (Reader and Writer)
-- DSL Reader: fix loosing metadata/info
+- DSL Reader: fix losing metadata/info
 
 - Aard 2 (slob) Reader:
 	- Fix adding css/js files as normal entries
@@ -116,7 +116,7 @@
 	- `glos.sourceLangName` and `glos.targetLangName` properties (with setters) as `str`
 		- Used in several plugins
 
-- Break compatibilty of plugins
+- Break compatibility of plugins
 	- Drop support for read and write functions (outside a class)
 	- Now we only support Reader class and Writer class
 	- Reader class must have these methods
@@ -146,7 +146,7 @@
 		- `finish(self)`
 	- Read options and write options must be set to their default values as class attributes
 		- See `pyglossary/plugins/csv_pyg.py` plugin for example
-	- `sortKey` must be an intance method of Writer, instead of a function outside any class
+	- `sortKey` must be an instance method of Writer, instead of a function outside any class
 		- Only for plugins that need sorting before write
 
 

--- a/doc/releases/4.1.0.md
+++ b/doc/releases/4.1.0.md
@@ -17,7 +17,7 @@ Please see the commit list for more!
 	+ Generate documentation for all formats
 		- Placed in [doc/p](../p), linked to in `README.md`
 		- Generating with `scripts/plugin-doc-gen.py` script
-		- Read list of dictionary tools/applicatios from TOML files in [plugins-meta/tools](../../plugins-meta/tools)
+		- Read list of dictionary tools/applications from TOML files in [plugins-meta/tools](../../plugins-meta/tools)
 
 - Add `Dockerfile` and `run-with-docker.sh` script
 
@@ -49,7 +49,7 @@ Please see the commit list for more!
 	- Remove directory after creating .zip, and some refactoring, [#294](https://github.com/ilius/pyglossary/issues/294)
 	- `DataEntry`: replace `inTmp` argument with `tmpPath` argument
 	- `Entry`: fix html pattern for hyperlinks, [#330](https://github.com/ilius/pyglossary/issues/330)
-	- Fix incorrect virutal env directory detection
+	- Fix incorrect virtual env directory detection
 	- Refactor `dataDir` detection, [#307](https://github.com/ilius/pyglossary/issues/307) [#316](https://github.com/ilius/pyglossary/issues/316)
 	- Show warning if failed to create user plugins directory
 	- fix possible exception in `log.emit`
@@ -98,7 +98,7 @@ Please see the commit list for more!
 - Text-based glossary code-base (effecting Tabfile, Kobo Dictfile, LDF)
 	- Optimize TextGlossaryReader 
 	- Change multi-file text glossary file names from `.N.txt` to `.txt.N` (where `N>=1`)
-	- Enable reading pyglossary-writen multi-file text glossary by adding `file_count=-1` to metadata
+	- Enable reading pyglossary-written multi-file text glossary by adding `file_count=-1` to metadata
 		+ because the number of files is not known when creating the first txt file
 
 
@@ -232,7 +232,7 @@ Please see the commit list for more!
 - DICT.org plugin:
 	- `installToDictd`: skip if target directory does not exist
 	- Make rendering dictd files a bit clear in pure txt
-	- Fix indention issue and add bword prefix as url
+	- Fix indentation issue and add bword prefix as url
 
 - Fixes and improvements in Dict.cc (SQLite3) plugin:
 	- Fix typo, and avoid iterating over cur, use `fetchall()`, [#296](https://github.com/ilius/pyglossary/issues/296)

--- a/doc/releases/4.5.0.md
+++ b/doc/releases/4.5.0.md
@@ -58,7 +58,7 @@
 
 # Refactoring
 
-- Plugins: replace import of `formats_common` from currect directory with `pyglossary.plugins.formats_common`
+- Plugins: replace import of `formats_common` from current directory with `pyglossary.plugins.formats_common`
 
 - Fix `logging.warn` method is deprecated, use `warning` instead, PR #360 by @BoboTiG
 

--- a/doc/stardict/stardict_sametypesequence.md
+++ b/doc/stardict/stardict_sametypesequence.md
@@ -1,5 +1,5 @@
 To convert to a StarDict dictionary with the `sametypesequence` option, use
-`sametypesequence=[type of defnitions]` write option.
+`sametypesequence=[type of definitions]` write option.
 
 If the sametypesequence option is set, it tells StarDict that each
 word's data in the .dict file will have the same sequence of datatypes.

--- a/plugins-meta/index.json
+++ b/plugins-meta/index.json
@@ -45,7 +45,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "add headwords title to begining of definition"
+				"comment": "add headwords title to beginning of definition"
 			}
 		},
 		"canRead": true,
@@ -252,10 +252,10 @@
 				"type": "bool",
 				"comment": "No control sequence in definitions"
 			},
-			"strict_string_convertion": {
+			"strict_string_conversion": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "Strict string convertion"
+				"comment": "Strict string conversion"
 			},
 			"process_html_in_key": {
 				"class": "BoolOption",
@@ -316,7 +316,7 @@
 			"target_encoding_overwrite": "",
 			"part_of_speech_color": "007000",
 			"no_control_sequence_in_defi": false,
-			"strict_string_convertion": false,
+			"strict_string_conversion": false,
 			"process_html_in_key": false,
 			"key_rstrip_chars": ""
 		}
@@ -444,7 +444,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "add headwords title to begining of definition"
+				"comment": "add headwords title to beginning of definition"
 			}
 		},
 		"canRead": true,
@@ -633,7 +633,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "add headwords title to begining of definition"
+				"comment": "add headwords title to beginning of definition"
 			}
 		},
 		"canRead": false,
@@ -950,7 +950,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "Add headwords title to begining of definition"
+				"comment": "Add headwords title to beginning of definition"
 			},
 			"pron_color": {
 				"class": "StrOption",
@@ -1085,7 +1085,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "Add headwords title to begining of definition"
+				"comment": "Add headwords title to beginning of definition"
 			}
 		},
 		"canRead": false,
@@ -1224,7 +1224,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "add headwords title to begining of definition"
+				"comment": "add headwords title to beginning of definition"
 			}
 		},
 		"canRead": false,
@@ -1594,7 +1594,7 @@
 			"word_title": {
 				"class": "BoolOption",
 				"type": "bool",
-				"comment": "Add headwords title to begining of definition"
+				"comment": "Add headwords title to beginning of definition"
 			}
 		},
 		"canRead": true,

--- a/pyglossary/core.py
+++ b/pyglossary/core.py
@@ -364,7 +364,7 @@ elif os.sep == "\\":  # Operating system is Windows
 	pip = "pip3"
 else:
 	raise RuntimeError(
-		f"Unknown path seperator(os.sep=={os.sep!r})"
+		f"Unknown path separator(os.sep=={os.sep!r})"
 		f", unknown operating system!"
 	)
 

--- a/pyglossary/entry.py
+++ b/pyglossary/entry.py
@@ -197,7 +197,7 @@ class Entry(BaseEntry):
 		# here `x` is raw entity, meaning a tuple of form (word, defi) or
 		# (word, defi, defiFormat)
 		# so x[0] is word(s) in bytes, that can be a str (one word),
-		# or a list or tuple (one word with or more alternaties)
+		# or a list or tuple (one word with or more alternatives)
 		if glos.rawEntryCompress:
 			return lambda x: key(loads(decompress(x))[0])
 		else:
@@ -252,7 +252,7 @@ class Entry(BaseEntry):
 		"""
 			returns string of word,
 				and all the alternate words
-				seperated by "|"
+				separated by "|"
 		"""
 		if isinstance(self._word, str):
 			return self._word

--- a/pyglossary/entry_base.py
+++ b/pyglossary/entry_base.py
@@ -42,7 +42,7 @@ class BaseEntry(object):
 		"""
 			returns bytes of word,
 				and all the alternate words
-				seperated by b"|"
+				separated by b"|"
 		"""
 		return self.s_word.encode("utf-8")
 
@@ -51,7 +51,7 @@ class BaseEntry(object):
 		"""
 			returns bytes of definition,
 				and all the alternate definitions
-				seperated by b"|"
+				separated by b"|"
 		"""
 		return self.defi.encode("utf-8")
 

--- a/pyglossary/glossary.py
+++ b/pyglossary/glossary.py
@@ -97,7 +97,7 @@ defaultSortKeyName = "headword_lower"
 
 class Glossary(GlossaryInfo, PluginManager, GlossaryType):
 	"""
-	Direct access to glos.data is droped
+	Direct access to glos.data is dropped
 	Use `glos.addEntryObj(glos.newEntry(word, defi, [defiFormat]))`
 		where both word and defi can be list (including alternates) or string
 	See help(glos.addEntryObj)
@@ -670,7 +670,7 @@ class Glossary(GlossaryInfo, PluginManager, GlossaryType):
 		"""
 		updates self._iter
 		depending on:
-			1- Wheather or not direct mode is On (self._readers not empty)
+			1- Whether or not direct mode is On (self._readers not empty)
 				or Off (self._readers empty)
 		"""
 		if not self._readers:  # indirect mode

--- a/pyglossary/gregorian.py
+++ b/pyglossary/gregorian.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/gpl.txt>.
-# Also avalable in /usr/share/common-licenses/GPL on Debian systems
+# Also available in /usr/share/common-licenses/GPL on Debian systems
 # or /usr/share/licenses/common/GPL3/license.txt on ArchLinux
 
 

--- a/pyglossary/html_utils.py
+++ b/pyglossary/html_utils.py
@@ -85,7 +85,7 @@ name2codepoint = {
 	"copy": 0x00a9,  # ©
 	"crarr": 0x21b5,  # ↵
 	"cup": 0x222a,  # ∪
-	"curren": 0x00a4,  # ¤
+	"current": 0x00a4,  # ¤
 	"Dagger": 0x2021,  # ‡
 	"dagger": 0x2020,  # †
 	"dArr": 0x21d3,  # ⇓

--- a/pyglossary/langs/langs.json
+++ b/pyglossary/langs/langs.json
@@ -1084,7 +1084,7 @@
 		"title_tag": "b"
 	},
 	{
-		"codes": ["nd", "nde"],
+		"codes": ["and", "nde"],
 		"name": "North Ndebele",
 		"alt_names": ["Ndebele", "amaNdebele", "Zimbabwean Ndebele", "North Ndebele"],
 		"script": ["Latin"],
@@ -1372,7 +1372,7 @@
 		"title_tag": "b"
 	},
 	{
-		"codes": ["so", "som"],
+		"codes": ["so", "some"],
 		"name": "Somali",
 		"alt_names": ["Af Soomaali"],
 		"script": ["Latin", "Arabic"],

--- a/pyglossary/langs/writing_system.py
+++ b/pyglossary/langs/writing_system.py
@@ -99,7 +99,7 @@ writingSystemList = [
 	),
 	WritingSystem(
 		name="Bengali-Assamese",
-		iso=(325, "Beng"),
+		iso=(325, "Being"),
 		unicode=["BENGALI"],
 		titleTag="big",
 		comma=", ",

--- a/pyglossary/plugin_lib/dictdlib.py
+++ b/pyglossary/plugin_lib/dictdlib.py
@@ -90,9 +90,9 @@ class DictDB:
 		read -- read-only access
 
 		write -- write-only access, truncates existing files, does not work
-		with .dz.  dict created if nonexistant.
+		with .dz.  dict created if nonexistent.
 
-		update -- read/write access, dict created if nonexistant.  Does not
+		update -- read/write access, dict created if nonexistent.  Does not
 		work with .dz.
 
 		Read can read dict or dict.dz files.  Write and update will NOT work
@@ -196,7 +196,7 @@ class DictDB:
 		retval = 0
 		entrylist = self.indexentries[word]
 		for i in range(len(entrylist) - 1, -1, -1):
-			# Go backwords so the del doesn't effect the index.
+			# Go backwards so the del doesn't effect the index.
 			if (start is None or start == entrylist[i][0]) and \
 				(size is None or size == entrylist[i][1]):
 				del(entrylist[i])

--- a/pyglossary/plugin_manager.py
+++ b/pyglossary/plugin_manager.py
@@ -127,7 +127,7 @@ class PluginManager(object):
 			cls.writeFormats.append(format)
 
 		if log.level <= core.TRACE:
-			prop.module  # to make sure imporing works
+			prop.module  # to make sure importing works
 
 	@classmethod
 	def loadPlugin(
@@ -179,7 +179,7 @@ class PluginManager(object):
 	@classmethod
 	def findPlugin(cls, query: str) -> "Optional[PluginProp]":
 		"""
-			find plugin by name or extention
+			find plugin by name or extension
 		"""
 		plugin = cls.plugins.get(query)
 		if plugin:

--- a/pyglossary/plugins/aard2_slob.py
+++ b/pyglossary/plugins/aard2_slob.py
@@ -37,7 +37,7 @@ optionsProp = {
 		comment="add alternate headwords as separate entries to slob",
 	),
 	"word_title": BoolOption(
-		comment="add headwords title to begining of definition",
+		comment="add headwords title to beginning of definition",
 	),
 }
 

--- a/pyglossary/plugins/appledict/indexes/__init__.py
+++ b/pyglossary/plugins/appledict/indexes/__init__.py
@@ -32,7 +32,7 @@ Dict[str, Callable[[Sequence[str], str], Sequence[str]]]
 submodules must register languages by adding (language name -> function)
 pairs to the mapping.
 
-function must follow signature bellow:
+function must follow signature below:
 	:param titles: flat iterable of title and altenrative titles
 	:param content: cleaned entry content
 	:return: iterable of indexes (str).

--- a/pyglossary/plugins/appledict/indexes/ru.py
+++ b/pyglossary/plugins/appledict/indexes/ru.py
@@ -34,7 +34,7 @@ morphy = pymorphy2.MorphAnalyzer()
 
 def ru(titles, _):
 	"""
-	gives a set of all declines, cases and other froms of word `title`.
+	gives a set of all declines, cases and other forms of word `title`.
 	note that it works only if title is one word.
 
 	:type titles: Sequence[str]
@@ -76,7 +76,7 @@ def _ru(title, a, a_norm):
 				# "й" and "и", "ё" and "е", so we're trying to avoid
 				# "* Duplicate index. Skipped..." warning.
 				# new: return indexes with original letters but check for
-				# occurence against "normal forms".
+				# occurrence against "normal forms".
 				word_norm = normalize(word)
 				if word_norm not in a_norm:
 					a.add(word)

--- a/pyglossary/plugins/babylon_bgl/bgl_info.py
+++ b/pyglossary/plugins/babylon_bgl/bgl_info.py
@@ -213,7 +213,7 @@ infoType3ByCode = {
 		"bgl_firstUpdated",
 		decode=decodeBglBinTime,
 	),
-	# bgl_firstUpdated was prevously called middleUpdated
+	# bgl_firstUpdated was previously called middleUpdated
 	# in rare cases, bgl_firstUpdated is before creationTime
 	# but usually it looks like to be the first update (after creation)
 	# in some cases, it's the same as lastUpdated

--- a/pyglossary/plugins/babylon_bgl/bgl_reader.py
+++ b/pyglossary/plugins/babylon_bgl/bgl_reader.py
@@ -90,8 +90,8 @@ optionsProp = {
 	"no_control_sequence_in_defi": BoolOption(
 		comment="No control sequence in definitions",
 	),
-	"strict_string_convertion": BoolOption(
-		comment="Strict string convertion",
+	"strict_string_conversion": BoolOption(
+		comment="Strict string conversion",
 	),
 	"process_html_in_key": BoolOption(
 		comment="Process HTML in (entry or info) key",
@@ -280,7 +280,7 @@ class BglReader(object):
 	_target_encoding_overwrite: str = ""
 	_part_of_speech_color: str = "007000"
 	_no_control_sequence_in_defi: bool = False
-	_strict_string_convertion: bool = False
+	_strict_string_conversion: bool = False
 	# process keys and alternates as HTML
 	# Babylon does not interpret keys and alternates as HTML text,
 	# however you may encounter many keys containing character references
@@ -656,7 +656,7 @@ class BglReader(object):
 		pos += Len
 		b_data = block.data[pos:]
 		# if b_name in (b"C2EEF3F6.html", b"8EAF66FD.bmp"):
-		# 	log.debug(f"Skipping non-useful file {b_name!r}")
+		# 	log.debug(f"Skipping useless file {b_name!r}")
 		# 	return
 		u_name = b_name.decode(self.sourceEncoding)
 		return self._glos.newDataEntry(
@@ -1056,7 +1056,7 @@ class BglReader(object):
 					self.charReferencesStat(b_text2, encoding)
 					if encoding == "cp1252":
 						b_text2 = replaceAsciiCharRefs(b_text2, encoding)
-					if self._strict_string_convertion:
+					if self._strict_string_conversion:
 						try:
 							u_text2 = b_text2.decode(encoding)
 						except UnicodeError:
@@ -1127,7 +1127,7 @@ class BglReader(object):
 				f"number of dollar indexes = {strip_count}",
 			)
 		# convert to unicode
-		if self._strict_string_convertion:
+		if self._strict_string_conversion:
 			try:
 				u_word_main = b_word_main.decode(self.sourceEncoding)
 			except UnicodeError:
@@ -1162,7 +1162,7 @@ class BglReader(object):
 		"""
 		b_word_main, strip_count = stripDollarIndexes(b_word)
 		# convert to unicode
-		if self._strict_string_convertion:
+		if self._strict_string_conversion:
 			try:
 				u_word_main = b_word_main.decode(self.sourceEncoding)
 			except UnicodeError:

--- a/pyglossary/plugins/crawler_dir.py
+++ b/pyglossary/plugins/crawler_dir.py
@@ -133,7 +133,7 @@ class Reader(object):
 		_, ext = splitext(fpath)
 		c_open = compressionOpenFunc(ext.lstrip("."))
 		if not c_open:
-			log.error(f"invalid extention {ext}")
+			log.error(f"invalid extension {ext}")
 			c_open = open
 		with c_open(fpath, "rt", encoding="utf-8") as _file:
 			words = splitByBarUnescapeNTB(_file.readline().rstrip("\n"))

--- a/pyglossary/plugins/csv_plugin.py
+++ b/pyglossary/plugins/csv_plugin.py
@@ -50,7 +50,7 @@ optionsProp = {
 		comment="Enable glossary info / metedata",
 	),
 	"word_title": BoolOption(
-		comment="add headwords title to begining of definition",
+		comment="add headwords title to beginning of definition",
 	),
 }
 

--- a/pyglossary/plugins/dict_org.py
+++ b/pyglossary/plugins/dict_org.py
@@ -55,7 +55,7 @@ def installToDictd(filename: str, dictzip: bool, title: str = "") -> None:
 	if subprocess.call(["/usr/sbin/dictdconfig", "-w"]) != 0:
 		log.error(
 			"failed to update /var/lib/dictd/db.list file"
-			", try manually runing: sudo /usr/sbin/dictdconfig -w"
+			", try manually running: sudo /usr/sbin/dictdconfig -w"
 		)
 
 	log.info("don't forget to restart dictd server")

--- a/pyglossary/plugins/dikt_json.py
+++ b/pyglossary/plugins/dikt_json.py
@@ -18,7 +18,7 @@ optionsProp = {
 	"enable_info": BoolOption(comment="Enable glossary info / metedata"),
 	"resources": BoolOption(comment="Enable resources / data files"),
 	"word_title": BoolOption(
-		comment="add headwords title to begining of definition",
+		comment="add headwords title to beginning of definition",
 	),
 }
 
@@ -62,8 +62,8 @@ class Writer(object):
 			st2 = re.sub(r'\n', '', st2)
 			st2 = re.sub(r'<div></div>', '', st2)
 			st2 = re.sub(r'<span></span>', '', st2)
-			# fix russina dictionary issues,
-			# such as hypenation in word (e.g. абб{[']}а{[/']}т)
+			# fix russian dictionary issues,
+			# such as hyphenation in word (e.g. абб{[']}а{[/']}т)
 			st2 = re.sub(r"\{\['\]\}", "", st2)
 			st2 = re.sub(r"\{\[/'\]\}", "", st2)
 			return dumps(st2, ensure_ascii=ascii)

--- a/pyglossary/plugins/ebook_epub2.py
+++ b/pyglossary/plugins/ebook_epub2.py
@@ -256,4 +256,4 @@ p.groupDefinition {
 			"application/x-dtbncx+xml",
 		)
 
-	# inherts write from EbookWriter
+	# inherits write from EbookWriter

--- a/pyglossary/plugins/freedict.py
+++ b/pyglossary/plugins/freedict.py
@@ -33,7 +33,7 @@ optionsProp = {
 		comment="Auto-detect and mark Right-to-Left text",
 	),
 	"word_title": BoolOption(
-		comment="Add headwords title to begining of definition",
+		comment="Add headwords title to beginning of definition",
 	),
 	"pron_color": StrOption(
 		comment="Pronunciation color",
@@ -90,7 +90,7 @@ class Reader(object):
 		"pn": "pronoun",
 		"pron": "pronoun",
 		"prep": "preposition",
-		"conj": "conjuction",
+		"conj": "conjunction",
 		"adj": "adjective",
 		"adv": "adverb",
 		# "numeral", "interjection", "suffix", "particle"

--- a/pyglossary/plugins/html_dir.py
+++ b/pyglossary/plugins/html_dir.py
@@ -40,7 +40,7 @@ optionsProp = {
 		comment="Path to css file",
 	),
 	"word_title": BoolOption(
-		comment="Add headwords title to begining of definition",
+		comment="Add headwords title to beginning of definition",
 	),
 }
 

--- a/pyglossary/plugins/json_plugin.py
+++ b/pyglossary/plugins/json_plugin.py
@@ -20,7 +20,7 @@ optionsProp = {
 	"enable_info": BoolOption(comment="Enable glossary info / metedata"),
 	"resources": BoolOption(comment="Enable resources / data files"),
 	"word_title": BoolOption(
-		comment="add headwords title to begining of definition",
+		comment="add headwords title to beginning of definition",
 	),
 }
 

--- a/pyglossary/plugins/tabfile.py
+++ b/pyglossary/plugins/tabfile.py
@@ -29,7 +29,7 @@ optionsProp = {
 		comment="Split up by given approximate file size\nexamples: 100m, 1g",
 	),
 	"word_title": BoolOption(
-		comment="Add headwords title to begining of definition",
+		comment="Add headwords title to beginning of definition",
 	),
 }
 

--- a/pyglossary/plugins/testformat.py
+++ b/pyglossary/plugins/testformat.py
@@ -38,7 +38,7 @@ class Reader(object):
 		# log.info(f"some useful message")
 		# here read info from file and set to Glossary object
 		self._glos.setInfo("name", "Test")
-		desc = "Test glossary craeted by a PyGlossary plugin"
+		desc = "Test glossary created by a PyGlossary plugin"
 		self._glos.setInfo("description", desc)
 		self._glos.setInfo("author", "Me")
 		self._glos.setInfo("copyright", "GPL")

--- a/pyglossary/ui/gtk3_utils/about.py
+++ b/pyglossary/ui/gtk3_utils/about.py
@@ -63,7 +63,7 @@ class AboutWidget(gtk.Box):
 		##
 		self.show_all()
 
-	# <a href="...">Somethig</a> does not work with TextView
+	# <a href="...">Something</a> does not work with TextView
 	def newTabWidgetTextView(
 		self,
 		text: str,

--- a/pyglossary/ui/gtk4_utils/about.py
+++ b/pyglossary/ui/gtk4_utils/about.py
@@ -93,7 +93,7 @@ class AboutWidget(gtk.Box):
 		##
 		self.show()
 
-	# <a href="...">Somethig</a> does not work with TextView
+	# <a href="...">Something</a> does not work with TextView
 	def newTabWidgetTextView(
 		self,
 		text: str,

--- a/pyglossary/ui/main.py
+++ b/pyglossary/ui/main.py
@@ -539,12 +539,12 @@ def main():
 		args.noColor = True
 
 	core.noColor = args.noColor
-	logHanlder = core.StdLogHandler(
+	logHandler = core.StdLogHandler(
 		noColor=args.noColor
 	)
 	log.setVerbosity(args.verbosity)
-	log.addHandler(logHanlder)
-	# with the logger setted up, we can import other pyglossary modules, so they
+	log.addHandler(logHandler)
+	# with the logger set up, we can import other pyglossary modules, so they
 	# can do some logging in right way.
 
 	for param1, param2 in UIBase.conflictingParams:
@@ -683,7 +683,7 @@ def main():
 			continue
 		config[key] = value
 
-	logHanlder.config = config
+	logHandler.config = config
 
 	convertOptions = {}
 	for key in convertOptionsKeys:

--- a/pyglossary/ui/ui_cmd_interactive.py
+++ b/pyglossary/ui/ui_cmd_interactive.py
@@ -28,7 +28,7 @@ To use this user interface:
 # https://github.com/prompt-toolkit/python-prompt-toolkit
 
 # The code for Python's cmd.Cmd was very ugly and hard to understand last I
-# cheched. But we don't use cmd module here, and nor does prompt_toolkit.
+# checked. But we don't use cmd module here, and nor does prompt_toolkit.
 
 # Completion func for Python's readline, silently (and stupidly) hides any
 # exception, and only shows the print if it's in the first line of function.
@@ -223,11 +223,11 @@ class MyPathCompleter(PathCompleter):
 		self.fs_action_names = fs_action_names
 
 	def file_filter(self, filename: str) -> bool:
-		# filename is full/absoule file path
+		# filename is full/absolute file path
 		return True
 
 	# def get_completions_exception(document, complete_event, e):
-	# 	log.error(f"Execption in get_completions: {e}")
+	# 	log.error(f"Exception in get_completions: {e}")
 
 	def get_completions(
 		self,
@@ -982,7 +982,7 @@ class UI(ui_cmd.UI):
 				for key, value in infoOverride.items():
 					flag = infoOverrideFlags.get(key)
 					if not flag:
-						log.error(f"unknow key {key} in infoOverride")
+						log.error(f"unknown key {key} in infoOverride")
 						continue
 					cmd.append(f"--{flag}={value}")
 
@@ -994,7 +994,7 @@ class UI(ui_cmd.UI):
 				if value is None:
 					continue
 				if key not in convertOptionsFlags:
-					log.error(f"unknow key {key} in convertOptions")
+					log.error(f"unknown key {key} in convertOptions")
 					continue
 				ftup = convertOptionsFlags[key]
 				if ftup is None:

--- a/pyglossary/ui/ui_gtk.py
+++ b/pyglossary/ui/ui_gtk.py
@@ -1394,7 +1394,7 @@ class UI(gtk.Dialog, MyDialog, UIBase):
 	def onDeleteEvent(self, widget, event):
 		self.destroy()
 		# gtk.main_quit()
-		# if callled while converting, main_quit does not exit program,
+		# if called while converting, main_quit does not exit program,
 		# it keeps printing warnings,
 		# and makes you close the terminal or force kill the process
 		sys.exit(0)

--- a/pyglossary/ui/ui_tk.py
+++ b/pyglossary/ui/ui_tk.py
@@ -821,7 +821,7 @@ class FormatOptionsDialog(tix.Toplevel):
 				event.y_root,
 			)
 			# do not pass the third argument (entry), so that the menu
-			# apears where the pointer is on its top-left corner
+			# appears where the pointer is on its top-left corner
 		finally:
 			# make sure to release the grab (Tk 8.0a1 only)
 			menu.grab_release()

--- a/tests/dsl_test.py
+++ b/tests/dsl_test.py
@@ -307,7 +307,7 @@ class DSLParserTestCase(unittest.TestCase):
 		after = """...,,,+++"""
 		self.assertEqual(after, parse(before))
 
-	def test_startsWtihClosingAndEndsWithOpening(self):
+	def test_startsWithClosingAndEndsWithOpening(self):
 		before = """[/c]...[i]"""
 		after = """..."""
 		self.assertEqual(after, parse(before))
@@ -327,7 +327,7 @@ class DSLParserTestCase(unittest.TestCase):
 		after = """...,,,"""
 		self.assertEqual(after, parse(before))
 
-	def test_nestedWithBrokenOutter(self):
+	def test_nestedWithBrokenOuter(self):
 		before = """[i][p]...[/p][/c]"""
 		after = """[p]...[/p]"""
 		self.assertEqual(after, parse(before))
@@ -337,7 +337,7 @@ class DSLParserTestCase(unittest.TestCase):
 		after = """...[i],,,[/i]+++"""
 		self.assertEqual(after, parse(before))
 
-	def test_wrongOrder2_WithConent(self):
+	def test_wrongOrder2_WithContent(self):
 		before = """[b]...[c red]...[/b]...[/c]"""
 		after = """[b]...[c red]...[/c][/b][c red]...[/c]"""
 		self.assertEqual(after, parse(before))

--- a/tests/g_ebook_epub2_test.py
+++ b/tests/g_ebook_epub2_test.py
@@ -44,7 +44,7 @@ class TestGlossaryEPUB2(TestGlossaryBase):
 	def convert_to_epub(
 		self,
 		inputFname,
-		ouputFname,
+		outputFname,
 		testId,
 		**convertArgs
 	):
@@ -53,7 +53,7 @@ class TestGlossaryEPUB2(TestGlossaryBase):
 			f"{inputFname.replace('.', '_')}-{testId}.epub"
 		)
 
-		expectedFilename = self.downloadFile(f"{ouputFname}.epub")
+		expectedFilename = self.downloadFile(f"{outputFname}.epub")
 		glos = self.glos = Glossary()
 		res = glos.convert(
 			inputFilename=inputFilename,

--- a/tests/g_stardict_test.py
+++ b/tests/g_stardict_test.py
@@ -164,7 +164,7 @@ class TestGlossaryStarDict(TestGlossaryBase):
 	def convert_stardict_txt(
 		self,
 		inputFname: str,
-		ouputFname: str,
+		outputFname: str,
 		testId: str,
 		syn=True,
 		**convertArgs
@@ -179,7 +179,7 @@ class TestGlossaryStarDict(TestGlossaryBase):
 		outputFilename = self.newTempFilePath(
 			f"{inputFname}-{testId}.txt"
 		)
-		expectedFilename = self.downloadFile(f"{ouputFname}.txt")
+		expectedFilename = self.downloadFile(f"{outputFname}.txt")
 		glos = self.glos = Glossary()
 
 		result = glos.convert(

--- a/tests/option_test.py
+++ b/tests/option_test.py
@@ -49,7 +49,7 @@ class TestOptionValidateBoolNumber(unittest.TestCase):
 		self.caseFailed(BoolOption, "Y", None)
 		self.caseFailed(BoolOption, "N", None)
 		self.caseFailed(BoolOption, "YESS", None)
-		self.caseFailed(BoolOption, "NOO", None)
+		self.caseFailed(BoolOption, "NO", None)
 		self.caseFailed(BoolOption, "123", None)
 		self.caseFailed(BoolOption, "a", None)
 


### PR DESCRIPTION
Found via `codespell -L te,ro,fo,tha,nin,nd,wel,vie,wasn,pres,dicline`