### PR TITLE
extract AppleDict meta-info (langs, title, author)

### DIFF
--- a/doc/p/appledict_bin.md
+++ b/doc/p/appledict_bin.md
@@ -26,12 +26,12 @@
 
 ### Dependencies for reading
 
-PyPI Links: [lxml](https://pypi.org/project/lxml)
+PyPI Links: [lxml](https://pypi.org/project/lxml), [biplist](https://pypi.org/project/biplist)
 
 To install, run:
 
 ```sh
-pip3 install lxml
+pip3 install lxml biplist
 ```
 
 

--- a/plugins-meta/index.json
+++ b/plugins-meta/index.json
@@ -197,7 +197,8 @@
 			"html_full": false
 		},
 		"readDepends": {
-			"lxml": "lxml"
+			"lxml": "lxml",
+			"biplist": "biplist"
 		}
 	},
 	{

--- a/pyglossary/plugins/appledict/__init__.py
+++ b/pyglossary/plugins/appledict/__init__.py
@@ -336,7 +336,10 @@ class Writer(object):
 				if front_back_matter
 				else ""
 			)
-			bundle_id = fileNameBase.replace(" ", "") if glos.getInfo("CFBundleIdentifier") is None else glos.getInfo("CFBundleIdentifier")
+			if glos.getInfo("CFBundleIdentifier") is None:
+				bundle_id = fileNameBase.replace(" ", "")
+			else:
+				bundle_id = glos.getInfo("CFBundleIdentifier")
 			toFile.write(
 				toStr(pkgutil.get_data(
 					__name__,

--- a/pyglossary/plugins/appledict/__init__.py
+++ b/pyglossary/plugins/appledict/__init__.py
@@ -336,13 +336,14 @@ class Writer(object):
 				if front_back_matter
 				else ""
 			)
+			bundle_id = fileNameBase.replace(" ", "") if glos.getInfo("CFBundleIdentifier") is None else glos.getInfo("CFBundleIdentifier")
 			toFile.write(
 				toStr(pkgutil.get_data(
 					__name__,
 					"templates/Info.plist",
 				)).format(
 					# identifier must be unique
-					CFBundleIdentifier=fileNameBase.replace(" ", ""),
+					CFBundleIdentifier=bundle_id,
 					CFBundleDisplayName=glos.getInfo("name"),
 					CFBundleName=fileNameBase,
 					DCSDictionaryCopyright=copyright,

--- a/pyglossary/plugins/appledict_bin.py
+++ b/pyglossary/plugins/appledict_bin.py
@@ -165,7 +165,8 @@ class Reader(object):
 		except (biplist.InvalidPlistException, biplist.NotBinaryPlistException):
 			try:
 				import plistlib
-				dict_metadata = plistlib.loads(open(infoplist_filepath, 'rb').read())
+				with open(infoplist_filepath, 'rb') as plist_file:
+					dict_metadata = plistlib.loads(plist_file.read())
 			except Exception as e:
 				raise IOError(
 					"'Info.plist' file is malformed, "
@@ -178,8 +179,13 @@ class Reader(object):
 		self._glos.setInfo('CFBundleIdentifier', dict_metadata.get('CFBundleIdentifier'))
 		if 'DCSDictionaryLanguages' in dict_metadata:
 			dict_metadata_langs = dict_metadata.get('DCSDictionaryLanguages')[0]
-			self._glos.setInfo('sourceLang', dict_metadata_langs['DCSDictionaryDescriptionLanguage'])
-			self._glos.setInfo('targetLang', dict_metadata_langs['DCSDictionaryIndexLanguage'])
+			import locale
+			dict_locale = dict_metadata_langs['DCSDictionaryDescriptionLanguage']
+			lang_code = locale.normalize(dict_locale).split('_')[0]
+			self._glos.setInfo('sourceLang', lang_code)
+			dict_locale = dict_metadata_langs['DCSDictionaryIndexLanguage']
+			lang_code = locale.normalize(dict_locale).split('_')[0]
+			self._glos.setInfo('targetLang', lang_code)
 
 	def __len__(self):
 		return self._wordCount


### PR DESCRIPTION
Done in this PR:
* Simplify logic of finding filepath of `Body.data`
* This is data that we can extract from `Info.plist` file:

```json
{
   "DCSDictionaryCSS": "DefaultStyle.css",
   "CFBundleName": "English",
   "DCSDictionaryUseSystemAppearance": true,
   "IDXDictionaryIndexes": [
      {
         "IDXIndexSupportDataID": false,
         "IDXIndexWritable": false,
         "IDXIndexPath": "KeyText.index",
         "IDXIndexAccessMethod": "com.apple.TrieAccessMethod",
         "IDXIndexName": "DCSKeywordIndex",
         "IDXIndexDataSizeLength": 2,
         "IDXIndexBigEndian": false,
         "TrieIndexCompressionType": 1,
         "IDXIndexDataFields": {
            "IDXFixedDataFields": [
               {
                  "IDXDataFieldName": "DCSPrivateFlag",
                  "IDXDataSize": 2
               }
            ],
            "IDXExternalDataFields": [
               {
                  "IDXDataFieldName": "DCSExternalBodyID",
                  "IDXDataSize": 8,
                  "IDXIndexName": "DCSBodyDataIndex"
               }
            ],
            "IDXVariableDataFields": [
               {
                  "IDXDataFieldName": "DCSKeyword",
                  "IDXDataSizeLength": 2
               },
               {
                  "IDXDataFieldName": "DCSHeadword",
                  "IDXDataSizeLength": 2
               },
               {
                  "IDXDataFieldName": "DCSEntryTitle",
                  "IDXDataSizeLength": 2
               },
               {
                  "IDXDataFieldName": "DCSAnchor",
                  "IDXDataSizeLength": 2
               },
               {
                  "IDXDataFieldName": "DCSYomiWord",
                  "IDXDataSizeLength": 2
               }
            ]
         },
         "IDXIndexKeyMatchingMethods": [
            "IDXExactMatch",
            "IDXPrefixMatch",
            "IDXCommonPrefixMatch",
            "IDXWildcardMatch",
            "IDXAllMatch"
         ],
         "TrieAuxiliaryDataOptions": {
            "HeapDataCompressionType": 3,
            "IDXIndexPath": "KeyText.data"
         }
      },
      {
         "IDXIndexSupportDataID": false,
         "IDXIndexWritable": false,
         "IDXIndexPath": "EntryID.index",
         "IDXIndexAccessMethod": "com.apple.TrieAccessMethod",
         "IDXIndexName": "DCSReferenceIndex",
         "IDXIndexDataSizeLength": 2,
         "IDXIndexBigEndian": false,
         "TrieIndexCompressionType": 1,
         "IDXIndexDataFields": {
            "IDXExternalDataFields": [
               {
                  "IDXDataFieldName": "DCSExternalBodyID",
                  "IDXDataSize": 8,
                  "IDXIndexName": "DCSBodyDataIndex"
               }
            ]
         },
         "IDXIndexKeyMatchingMethods": [
            "IDXExactMatch"
         ],
         "TrieAuxiliaryDataOptions": {
            "IDXIndexPath": "EntryID.data"
         }
      },
      {
         "IDXIndexPath": "Body.data",
         "IDXIndexAccessMethod": "com.apple.HeapAccessMethod",
         "IDXIndexName": "DCSBodyDataIndex",
         "IDXIndexBigEndian": false,
         "IDXIndexDataFields": {
            "IDXVariableDataFields": [
               {
                  "IDXDataFieldName": "DCSBodyData",
                  "IDXDataSizeLength": 4
               }
            ]
         },
         "IDXIndexWritable": false,
         "HeapDataCompressionType": 2,
         "IDXIndexSupportDataID": true
      }
   ],
   "DCSDictionaryManufacturerName": "Apple Inc.",
   "CFBundleDevelopmentRegion": "en",
   "DCSDictionaryFrontMatterReferenceID": "fbm_index",
   "CFBundleShortVersionString": "2.6",
   "DCSElementXPath": {
      "pos": "//span[@class=\"sg\"]/descendant::span[@class=\"pos\"][1]",
      "definitions": "//span[contains(@class,\"x_xd0\")][1]/descendant::span[contains(@class,\"x_xd1\") and not(contains(@class,\"t_subsense\"))]/descendant::span[@class=\"df\" or @class=\"xrg\"][1][not(@d:prtl)]",
      "pronunciation": "(//span[@class=\"pr\" or @class=\"prx\"]/descendant::span[contains(@class,\"ph\")])[1]"
   },
   "DCSDictionaryDetailedDisplayName": "British English",
   "CFBundleInfoDictionaryVersion": "6.0",
   "CFBundleIdentifier": "com.apple.dictionary.ODE",
   "DCSDictionaryPrimaryLanguage": "en_GB",
   "DCSDictionaryDefaultPrefs": {
      "version": "1",
      "pronunciation": "0"
   },
   "DCSDictionaryPreviewMarkupVersion": 1,
   "CFBundleDisplayName": "Oxford Dictionary of English",
   "DCSDictionaryCopyright": "Oxford Dictionary of English<br/>Copyright © 2010, 2022 by Oxford University Press. All rights reserved.",
   "IDXDictionaryVersion": 3,
   "DCSDictionaryNativeDisplayName": "Dictionary",
   "DCSBuildToolVersion": 3,
   "DCSDictionaryLanguages": [
      {
         "DCSDictionaryDescriptionLanguage": "en_GB",
         "DCSDictionaryIndexLanguage": "en_GB"
      }
   ]
}
```