### PR TITLE
Tests for AppleDict binary

### DIFF
--- a/tests/g_appledict_bin_test.py
+++ b/tests/g_appledict_bin_test.py
@@ -14,6 +14,20 @@ class TestGlossaryAppleDictBin(TestGlossaryBase):
 	def __init__(self, *args, **kwargs):
 		TestGlossaryBase.__init__(self, *args, **kwargs)
 
+		self.dataFileCRC32.update({
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/Body.data": "3c073986",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/DefaultStyle.css": "a83210cb",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/EntryID.data": "37305249",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/EntryID.index": "8c30a3fa",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/Info.plist": "fa73dd65",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/KeyText.data": "aefe15e0",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/KeyText.index": "b723c5b2",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/MyDictionary.xsl": "023de1ea",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/MyDictionary_prefs.html": "09a9f6e9",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/appledict-source_expected.xml": "9c30ae49",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/stardict_expected.xml": "bf521bfc",
+		})
+
 	def test_fix_links(self):
 		glos = Glossary()
 		reader = Reader(glos)
@@ -45,3 +59,40 @@ class TestGlossaryAppleDictBin(TestGlossaryBase):
 			),
 			'<a href="bword://test" title="test">',
 		)
+
+	def test_binary_to_source(self):
+		self.glos = Glossary()
+
+		folder_input = 'appledict-bin/002-appledict-bin-no-morphology.dictionary'
+		folder_output = 'no-morphology.source'
+
+		result = self.glos.convert(
+			inputFilename=f'./{folder_input}',
+			outputFilename=f'./{folder_output}',
+			inputFormat="AppleDictBin",
+			outputFormat="AppleDict",
+		)
+
+		self.compareTextFiles(
+			f'./{folder_output}/no-morphology_source.xml',
+			self.downloadFile('appledict-bin/002-appledict-bin-no-morphology.dictionary/appledict-source_expected.xml'),
+		)
+
+	def test_binary_to_stardict(self):
+		self.glos = Glossary()
+
+		folder_input = 'appledict-bin/002-appledict-bin-no-morphology.dictionary'
+		folder_output = 'no-morphology.source'
+
+		result = self.glos.convert(
+			inputFilename=f'./{folder_input}',
+			outputFilename=f'./{folder_output}/stardict.xml',
+			inputFormat="AppleDictBin",
+			outputFormat="StardictTextual",
+		)
+
+		self.compareTextFiles(
+			f'./{folder_output}/stardict.xml',
+			self.downloadFile('appledict-bin/002-appledict-bin-no-morphology.dictionary/stardict_expected.xml'),
+		)
+

--- a/tests/g_appledict_bin_test.py
+++ b/tests/g_appledict_bin_test.py
@@ -1,11 +1,11 @@
 import sys
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 import unittest
 
 rootDir = dirname(dirname(abspath(__file__)))
 sys.path.insert(0, rootDir)
 
-from tests.glossary_test import TestGlossaryBase
+from tests.glossary_test import TestGlossaryBase, dataDir
 from pyglossary.glossary import Glossary
 from pyglossary.plugins.appledict_bin import Reader
 
@@ -19,13 +19,14 @@ class TestGlossaryAppleDictBin(TestGlossaryBase):
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/DefaultStyle.css": "a83210cb",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/EntryID.data": "37305249",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/EntryID.index": "8c30a3fa",
+			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/Images/_internal_dictionary.png": "da4d4eb1",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/Info.plist": "fa73dd65",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/KeyText.data": "aefe15e0",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/KeyText.index": "b723c5b2",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/MyDictionary.xsl": "023de1ea",
 			"appledict-bin/002-appledict-bin-no-morphology.dictionary/Contents/MyDictionary_prefs.html": "09a9f6e9",
-			"appledict-bin/002-appledict-bin-no-morphology.dictionary/appledict-source_expected.xml": "9c30ae49",
-			"appledict-bin/002-appledict-bin-no-morphology.dictionary/stardict_expected.xml": "bf521bfc",
+			"appledict-bin/002-appledict-bin-no-morphology.txt": "4afadab4",
+			"appledict-bin/002-appledict-bin-no-morphology.txt_res/style.css": "a83210cb"
 		})
 
 	def test_fix_links(self):
@@ -60,39 +61,39 @@ class TestGlossaryAppleDictBin(TestGlossaryBase):
 			'<a href="bword://test" title="test">',
 		)
 
-	def test_binary_to_source(self):
+	def test_appledict_binary_to_txt(self):
 		self.glos = Glossary()
 
-		folder_input = 'appledict-bin/002-appledict-bin-no-morphology.dictionary'
-		folder_output = 'no-morphology.source'
+		baseName = "002-appledict-bin-no-morphology"
+		inputDirPath = self.downloadDir(
+			f"appledict-bin/{baseName}.dictionary",
+			[
+				"Contents/Body.data",
+				"Contents/DefaultStyle.css",
+				"Contents/EntryID.data",
+				"Contents/EntryID.index",
+				"Contents/Images/_internal_dictionary.png",
+				"Contents/Info.plist",
+				"Contents/KeyText.data",
+				"Contents/KeyText.index",
+				"Contents/MyDictionary.xsl",
+				"Contents/MyDictionary_prefs.html",
+			],
+		)
+		outputFilePath = self.newTempFilePath(f"{baseName}.txt")
+		expectedOutputFilePath = self.downloadFile(f"appledict-bin/{baseName}.txt")
 
 		result = self.glos.convert(
-			inputFilename=f'./{folder_input}',
-			outputFilename=f'./{folder_output}',
+			inputFilename=inputDirPath,
+			outputFilename=outputFilePath,
 			inputFormat="AppleDictBin",
-			outputFormat="AppleDict",
+			outputFormat="Tabfile",
 		)
 
 		self.compareTextFiles(
-			f'./{folder_output}/no-morphology_source.xml',
-			self.downloadFile('appledict-bin/002-appledict-bin-no-morphology.dictionary/appledict-source_expected.xml'),
+			outputFilePath,
+			expectedOutputFilePath,
 		)
 
-	def test_binary_to_stardict(self):
-		self.glos = Glossary()
 
-		folder_input = 'appledict-bin/002-appledict-bin-no-morphology.dictionary'
-		folder_output = 'no-morphology.source'
-
-		result = self.glos.convert(
-			inputFilename=f'./{folder_input}',
-			outputFilename=f'./{folder_output}/stardict.xml',
-			inputFormat="AppleDictBin",
-			outputFormat="StardictTextual",
-		)
-
-		self.compareTextFiles(
-			f'./{folder_output}/stardict.xml',
-			self.downloadFile('appledict-bin/002-appledict-bin-no-morphology.dictionary/stardict_expected.xml'),
-		)
 

--- a/tests/glossary_test.py
+++ b/tests/glossary_test.py
@@ -88,9 +88,12 @@ class TestGlossaryBase(unittest.TestCase):
 			if isdir(direc):
 				rmtree(direc)
 
+	def fixDownloadFilename(self, filename):
+		return filename.replace("/", "__").replace("\\", "__")
+
 	def downloadFile(self, filename):
 		_crc32 = self.dataFileCRC32[filename]
-		fpath = join(dataDir, filename.replace("/", "__"))
+		fpath = join(dataDir, self.fixDownloadFilename(filename))
 		if isfile(fpath):
 			with open(fpath, mode="rb") as _file:
 				data = _file.read()
@@ -109,6 +112,15 @@ class TestGlossaryBase(unittest.TestCase):
 		with open(fpath, mode="wb") as _file:
 			_file.write(data)
 		return fpath
+
+	def downloadDir(self, dirName: str, files: "List[str]") -> str:
+		dirPath = join(dataDir, self.fixDownloadFilename(dirName))
+		for fileRelPath in files:
+			filePath = self.downloadFile(join(dirName, fileRelPath))
+			newFilePath = join(dirPath, fileRelPath)
+			os.makedirs(dirname(newFilePath), exist_ok=True)
+			os.rename(filePath, newFilePath)
+		return dirPath
 
 	def newTempFilePath(self, filename):
 		fpath = join(self.tempDir, filename)


### PR DESCRIPTION
I added test files to https://github.com/soshial/pyglossary-test/tree/appledict-no-morph.

Could you please help making these tests run, @ilius?
1. How do I download whole dir instead of each file?
2. How to make paths point to the downloaded files? Now it points to `/Users/XXXX/Library/Caches/PyGlossary/test/appledict-bin/002-appledict-bin-no-morphology.dictionary`.