### PR TITLE
fix: typing.re is deprecated, import directly from typing instead. ty…

### DIFF
--- a/pyglossary/apple_utils.py
+++ b/pyglossary/apple_utils.py
@@ -10,7 +10,7 @@
 # in all operating systems
 
 import re
-import typing.re
+from typing import Match
 
 from .core import log
 
@@ -70,7 +70,7 @@ cssParamPattern = re.compile(
 	r"(-(apple|webkit)-[a-z\-]+)",
 )
 
-def _subCSS(m: "typing.re.Match") -> str:
+def _subCSS(m: Match) -> str:
 	key = m.group(0)
 	value = cssMapping.get(key)
 	if value is None:

--- a/pyglossary/plugins/appledict/_content.py
+++ b/pyglossary/plugins/appledict/_content.py
@@ -25,8 +25,7 @@
 
 import logging
 import re
-from typing import Any
-from typing.re import Pattern
+from typing import Any, Pattern
 from xml.sax.saxutils import quoteattr, unescape
 
 from pyglossary.text_utils import toStr


### PR DESCRIPTION
…ping.re will be removed in Python 3.12