### PR TITLE
Update pyicu docs for Debian

### DIFF
--- a/doc/pyicu.md
+++ b/doc/pyicu.md
@@ -2,7 +2,8 @@
 
 ## Installation on Linux
 
-- Debian/Ubuntu: `sudo apt install pyicu`
+- Debian `sudo apt-get install python3-icu`
+- Ubuntu: `sudo apt install pyicu`
 - openSUSE: `sudo zypper install python3-PyICU`
 - Fedora: `sudo dnf install python3-pyicu`
 - Other distros:


### PR DESCRIPTION
Debian uses the python3-icu package and ubuntu uses the pyicu package, per the docs https://gitlab.pyicu.org/main/pyicu#installing-pyicu and my experience with debain bullseye.