### PR TITLE
AppleDict-bin: fix lxml parsing of 4-byte unicode symbols

### DIFF
--- a/pyglossary/plugins/appledict_bin/__init__.py
+++ b/pyglossary/plugins/appledict_bin/__init__.py
@@ -456,7 +456,7 @@ class Reader(object):
 		if not entryFull:
 			return None
 		try:
-			entryRoot = etree.fromstring(entryFull)
+			entryRoot = etree.parse(BytesIO(entryBytes))
 		except etree.XMLSyntaxError as e:
 			log.error(
 				f"{entryFull=}",
@@ -724,7 +724,6 @@ class Reader(object):
 				articleAddress = ArticleAddress(sectionOffset, pos)
 				pos += offset
 				entryBytes = buffer[pos:pos + chunkLen]
-				entryBytes = entryBytes.replace(b"\x00", b"")
 
 				pos += chunkLen
 				yield entryBytes, articleAddress


### PR DESCRIPTION
There is some [lxml library bug](https://bugs.launchpad.net/lxml/+bug/1949271), but etree creation is done successfully with entryRoot = etree.parse(BytesIO(entryBytes)). But I get another error: AttributeError: 'lxml.etree._ElementTree' object has no attribute 'nsmap'.