### PR TITLE
stardict xdxf: handle text within <br></br>

### DIFF
--- a/pyglossary/xdxf/transform.py
+++ b/pyglossary/xdxf/transform.py
@@ -229,6 +229,7 @@ class XdxfTransformer:
 	def _write_br(self, hf: "T_htmlfile", child: "Element") -> None:
 		from lxml import etree as ET
 		hf.write(ET.Element("br"))
+		self.writeChildrenOf(hf, child)
 
 	def _write_c(self, hf: "T_htmlfile", child: "Element") -> None:
 		color = child.attrib.get("c", "green")


### PR DESCRIPTION
Sometimes the definition body lives inside a `<br></br>` pair, e.g.
```
<k>lexidium</k><br><b>lexĭdĭum</b>, <b>i</b>, <i>n.</i>, = leci/dion, <i>a little word</i>: lexidia colligere, Gell. 18, 7, 3.</br>
```

So perhaps it is a good idea to write the children of `<br>` as well?