### PR TITLE
Replace dictzip with idzip

### DIFF
--- a/pyglossary/os_utils.py
+++ b/pyglossary/os_utils.py
@@ -68,22 +68,21 @@ def runDictzip(filename: Union[str, Path]) -> None:
 		return
 
 	filename = Path(filename)
-	if not filename.is_file():
-		log.error(f"{filename} is not a regular file")
-		return
 	destination = filename.parent/(filename.name + ".dz")
 
-	with open(filename, "rb") as inp_file, open(destination, "wb") as out_file:
-		inputinfo = os.fstat(inp_file.fileno())
-		log.debug("compressing %s to %s", filename, destination)
-		idzip.compressor.compress(
-			inp_file,
-			inputinfo.st_size,
-			out_file,
-			filename.name,
-			int(inputinfo.st_mtime))
-
-	filename.unlink()
+	try:
+		with open(filename, "rb") as inp_file, open(destination, "wb") as out_file:
+			inputinfo = os.fstat(inp_file.fileno())
+			log.debug("compressing %s to %s", filename, destination)
+			idzip.compressor.compress(
+				inp_file,
+				inputinfo.st_size,
+				out_file,
+				filename.name,
+				int(inputinfo.st_mtime))
+		filename.unlink()
+	except OSError as error:
+		log.error(str(error))
 
 
 def _rmtreeError(

--- a/pyglossary/os_utils.py
+++ b/pyglossary/os_utils.py
@@ -68,6 +68,9 @@ def runDictzip(filename: Union[str, Path]) -> None:
 		return
 
 	filename = Path(filename)
+	if not filename.is_file():
+		log.error(f"{filename} is not a regular file")
+		return
 	destination = filename.parent/(filename.name + ".dz")
 
 	with open(filename, "rb") as inp_file, open(destination, "wb") as out_file:

--- a/pyglossary/plugins/stardict.py
+++ b/pyglossary/plugins/stardict.py
@@ -861,6 +861,9 @@ class Writer:
 				yield from self.writeGeneral()
 		if self._dictzip:
 			runDictzip(f"{self._filename}.dict")
+			syn_file = f"{self._filename}.syn"
+			if not self._merge_syns and os.path.exists(syn_file):
+				runDictzip(syn_file)
 
 	def fixDefi(self, defi: str, defiFormat: str) -> str:
 		# for StarDict 3.0:

--- a/scripts/test-deps.sh
+++ b/scripts/test-deps.sh
@@ -1,1 +1,2 @@
-python -m pip install  lxml beautifulsoup4 biplist marisa-trie mistune html5lib PyICU
+python -m pip install \
+  PyICU beautifulsoup4 biplist html5lib python-idzip lxml marisa-trie mistune

--- a/tests/rundictzip_test.py
+++ b/tests/rundictzip_test.py
@@ -1,7 +1,8 @@
 import gzip
 import tempfile
-import unittest
 from pathlib import Path
+
+from glossary_errors_test import TestGlossaryErrorsBase
 
 from pyglossary.os_utils import runDictzip
 
@@ -15,7 +16,7 @@ culpa qui officia deserunt mollit anim id est laborum.
 """
 
 
-class AsciiLowerUpperTest(unittest.TestCase):
+class AsciiLowerUpperTest(TestGlossaryErrorsBase):
 	def make_dz(self, path: Path) -> Path:
 		"""Get path of dzipped file contains TEXT."""
 		test_file_path = Path(path)/"test_file.txt"
@@ -31,9 +32,15 @@ class AsciiLowerUpperTest(unittest.TestCase):
 			self.assertTrue(result_file_path.exists())
 			self.assertTrue(result_file_path.is_file())
 
-	def test_compressing_text(self):
+	def test_compressed_matches(self):
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			result_file_path = self.make_dz(tmp_dir)
 			with gzip.open(result_file_path, 'r') as file:
 				result = file.read().decode()
 		self.assertEqual(result, TEXT)
+
+	def test_missing_target(self):
+		filename = 'NOT_EXISTED_PATH/file.txt'
+		expected_msg = f"{filename} is not a regular file"
+		runDictzip(filename)
+		self.assertLogError(expected_msg)

--- a/tests/rundictzip_test.py
+++ b/tests/rundictzip_test.py
@@ -1,0 +1,39 @@
+import gzip
+import tempfile
+import unittest
+from pathlib import Path
+
+from pyglossary.os_utils import runDictzip
+
+TEXT = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+"""
+
+
+class AsciiLowerUpperTest(unittest.TestCase):
+	def make_dz(self, path: Path) -> Path:
+		"""Get path of dzipped file contains TEXT."""
+		test_file_path = Path(path)/"test_file.txt"
+		result_file_path = test_file_path.parent/(test_file_path.name + ".dz")
+		with open(test_file_path, "a") as tmp_file:
+			tmp_file.write(TEXT)
+		runDictzip(str(test_file_path))
+		return result_file_path
+
+	def test_compressed_exists(self):
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			result_file_path = self.make_dz(tmp_dir)
+			self.assertTrue(result_file_path.exists())
+			self.assertTrue(result_file_path.is_file())
+
+	def test_compressing_text(self):
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			result_file_path = self.make_dz(tmp_dir)
+			with gzip.open(result_file_path, 'r') as file:
+				result = file.read().decode()
+		self.assertEqual(result, TEXT)

--- a/tests/rundictzip_test.py
+++ b/tests/rundictzip_test.py
@@ -16,6 +16,8 @@ culpa qui officia deserunt mollit anim id est laborum.
 """
 
 
+# TODO Test also dictzip func
+# TODO Check if dictzip in GH Action and avoid if not
 class AsciiLowerUpperTest(TestGlossaryErrorsBase):
 	def make_dz(self, path: Path) -> Path:
 		"""Get path of dzipped file contains TEXT."""

--- a/tests/rundictzip_test.py
+++ b/tests/rundictzip_test.py
@@ -41,6 +41,6 @@ class AsciiLowerUpperTest(TestGlossaryErrorsBase):
 
 	def test_missing_target(self):
 		filename = 'NOT_EXISTED_PATH/file.txt'
-		expected_msg = f"{filename} is not a regular file"
+		expected_msg = f"[Errno 2] No such file or directory: '{filename}'"
 		runDictzip(filename)
 		self.assertLogError(expected_msg)


### PR DESCRIPTION
### Alternative

[izip](https://github.com/bauman/python-idzip/blob/master/setup.py) is maintained Python alternative to `dictzip` utility.

### Rationale

The pure python dependency instead of a binary, easy to obtain, no need to subprocess it.

### Changes

- `dictzip` call replaced with `idzip`, while `runDictzip` contract are kept as close to `dictzip` version as possible.
- `stardict` writer compresses also a syn file when exists and `dictzip` opt is `True` for consistence.
- Few simple test cases for `runDictzip`.

### Notes

`idzip` had been tried on the [DPD](https://digitalpalidictionary.github.io/) stardict. It does the job as same efficient as the `dictzip`, even a few percents faster. On a 1G random binary blob it shows a bit worse performance than `dictzip` do.

_P. S.:_ I will be out of a PC for a few next days, so sorry for possible long response time.