### PR TITLE
Replace dictzip with idzip [2]

### DIFF
--- a/pyglossary/core_test.py
+++ b/pyglossary/core_test.py
@@ -20,12 +20,13 @@ class MockLogHandler(logging.Handler):
 		else:
 			self.recordsByLevel[level] = [record]
 
-	def popLog(self, level: int, msg: str) -> "logging.LogRecord | None":
+	def popLog(self, level: int, msg: str, partial=False) -> "logging.LogRecord | None":
 		if level not in self.recordsByLevel:
 			return None
 		records = self.recordsByLevel[level]
 		for index, record in enumerate(records):
-			if record.getMessage() == msg:
+			rec_msg = record.getMessage()
+			if msg == rec_msg or (msg in rec_msg and partial):
 				return records.pop(index)
 		return None
 

--- a/pyglossary/os_utils.py
+++ b/pyglossary/os_utils.py
@@ -100,19 +100,28 @@ def _dictzip(filename: str) -> bool:
 		log.error(f"dictzip exit {retcode}: {err_msg}")
 	return True
 
-def _nozip(filename: str) -> bool:
-	log.warning(
-		"Dictzip compression requires idzip module or dictzip utility,"
-		f" run `{core.pip} install python-idzip` to install or make sure"
-		" dictzip is in your $PATH")
-	return False
 
+def runDictzip(filename: str, method='') -> bool:
+	"""
+	Compress file into dictzip format.
 
-def runDictzip(filename: str) -> None:
-	"""Compress file into dictzip format."""
-	for fun in (_idzip, _dictzip, _nozip):
-		if fun(filename):
-			return
+	Returns True when succeed.
+	"""
+	# FIXME Shorten
+	if method == 'idzip':
+		return _idzip(filename)
+	if method == 'dictzip':
+		return _dictzip(filename)
+
+	res = _idzip(filename)
+	if not res:
+		res = _dictzip
+	if not res:
+		log.warning(
+			"Dictzip compression requires idzip module or dictzip utility,"
+			f" run `{core.pip} install python-idzip` to install or make sure"
+			" dictzip is in your $PATH")
+	return res
 
 
 def _rmtreeError(

--- a/pyglossary/os_utils.py
+++ b/pyglossary/os_utils.py
@@ -101,27 +101,18 @@ def _dictzip(filename: str) -> bool:
 	return True
 
 
-def runDictzip(filename: str, method='') -> bool:
-	"""
-	Compress file into dictzip format.
-
-	Returns True when succeed.
-	"""
-	# FIXME Shorten
-	if method == 'idzip':
-		return _idzip(filename)
-	if method == 'dictzip':
-		return _dictzip(filename)
-
-	res = _idzip(filename)
-	if not res:
-		res = _dictzip
+def runDictzip(filename: str | Path, method="") -> None:
+	"""Compress file into dictzip format."""
+	res = None
+	if method in ["", "idzip"]:
+		res = _idzip(filename)
+	if not res and method in ["", "dictzip"]:
+		res = _dictzip(filename)
 	if not res:
 		log.warning(
 			"Dictzip compression requires idzip module or dictzip utility,"
 			f" run `{core.pip} install python-idzip` to install or make sure"
 			" dictzip is in your $PATH")
-	return res
 
 
 def _rmtreeError(

--- a/pyglossary/os_utils.py
+++ b/pyglossary/os_utils.py
@@ -87,16 +87,17 @@ def _dictzip(filename: str) -> bool:
 	dictzipCmd = shutil.which("dictzip")
 	if not dictzipCmd:
 		return False
-	b_out, b_err = subprocess.Popen(
-		[dictzipCmd, filename],
-		stdout=subprocess.PIPE).communicate()
 	log.debug(f"dictzip command: {dictzipCmd!r}")
-	if b_err:
-		err = b_err.decode("utf-8").replace('\n', ' ')
-		log.error(f"dictzip error: {err}")
-	if b_out:
-		out = b_out.decode("utf-8").replace('\n', ' ')
-		log.error(f"dictzip error: {out}")
+	try:
+		subprocess.run(
+			[dictzipCmd, filename],
+			check=True,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.STDOUT)
+	except subprocess.CalledProcessError as proc_err:
+		err_msg = proc_err.output.decode("utf-8").replace("\n", ";")
+		retcode = proc_err.returncode
+		log.error(f"dictzip exit {retcode}: {err_msg}")
 	return True
 
 def _nozip(filename: str) -> bool:

--- a/tests/dictzip_test.py
+++ b/tests/dictzip_test.py
@@ -61,18 +61,21 @@ class TestDictzip(TestGlossaryErrorsBase):
 			result = file.read().decode()
 		self.assertEqual(result, TEXT)
 
+	def test_dictzip_missing_target(self) -> None:
+		method="idzip"
+		filename = "/NOT_EXISTED_PATH/file.txt"
+		expected = f"No such file or directory: '{filename}'"
+		runDictzip(filename, method)
+		self.skip_on_dep(method)
+		err = self.mockLog.popLog(logging.ERROR, expected, partial=True)
+		self.assertIsNotNone(err)
 
-# class TestDictzipErrors(TestDictzipBase):
-# 	def tearDown(self):
-# 		self.mockLog.clear()
-# 		super().tearDown()
-# 
-# 	def on_missing_target(self, func: Callable[[str], bool]) -> None:
-# 		filename = "/NOT_EXISTED_PATH/file.txt"
-# 		self._run(func, filename)
-# 		err_num = self.mockLog.printRemainingErrors()
-# 		self.assertEqual(err_num, 1)
-# 
-# 	# FIXME
-# 	#test_idzip_missing_target = partialmethod(on_missing_target, func=_idzip)
-# 	#test_dictzip_missing_target = partialmethod(on_missing_target, func=_dictzip)
+	def test_idzip_missing_target(self) -> None:
+		method="dictzip"
+		filename = "/NOT_EXISTED_PATH/boilerplate.txt"
+		expected = f'Cannot open "{filename}"'
+		runDictzip(filename, method)
+		self.skip_on_dep(method)
+		err = self.mockLog.popLog(logging.ERROR, expected, partial=True)
+		self.assertIsNotNone(err)
+

--- a/tests/dictzip_test.py
+++ b/tests/dictzip_test.py
@@ -2,11 +2,13 @@ import gzip
 import tempfile
 from functools import partialmethod
 from pathlib import Path
+from typing import Callable
 
-import idzip as _  # noqa: F401
 from glossary_errors_test import TestGlossaryErrorsBase
 
 from pyglossary.os_utils import _dictzip, _idzip
+
+FUNC_TYPE = Callable[[str], bool]
 
 TEXT = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -18,24 +20,30 @@ culpa qui officia deserunt mollit anim id est laborum.
 """
 
 
-# TODO Check if dictzip in GH Action and avoid if not
-class DictzipTest(TestGlossaryErrorsBase):
-	def make_dz(self, func, path: Path) -> Path:
+class TestDictzipBase(TestGlossaryErrorsBase):
+	def _run(self, func: FUNC_TYPE, filename: str | Path) -> None:
+		done = func(str(filename))
+		if not done:
+			self.skipTest(f'Missing dependency for {func.__name__}')
+
+
+class TestDictzip(TestDictzipBase):
+	def make_dz(self, func: FUNC_TYPE, path: str | Path) -> Path:
 		"""Get path of dzipped file contains TEXT."""
 		test_file_path = Path(path)/"test_file.txt"
 		result_file_path = test_file_path.parent/(test_file_path.name + ".dz")
 		with open(test_file_path, "a") as tmp_file:
 			tmp_file.write(TEXT)
-		func(str(test_file_path))
+		self._run(func, test_file_path)
 		return result_file_path
 
-	def is_compressed_exists(self, func):
+	def is_compressed_exists(self, func: FUNC_TYPE) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			result_file_path = self.make_dz(func, tmp_dir)
 			self.assertTrue(result_file_path.exists())
 			self.assertTrue(result_file_path.is_file())
 
-	def is_compressed_matches(self, func):
+	def is_compressed_matches(self, func: FUNC_TYPE) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			result_file_path = self.make_dz(func, tmp_dir)
 			with gzip.open(result_file_path, 'r') as file:
@@ -49,14 +57,14 @@ class DictzipTest(TestGlossaryErrorsBase):
 	test_dictzip_compressed_matches = partialmethod(is_compressed_matches, _dictzip)
 
 
-class DictzipErrorsTest(TestGlossaryErrorsBase):
+class TestDictzipErrors(TestDictzipBase):
 	def tearDown(self):
 		self.mockLog.clear()
 		super().tearDown()
 
-	def on_missing_target(self, func):
+	def on_missing_target(self, func: FUNC_TYPE) -> None:
 		filename = '/NOT_EXISTED_PATH/file.txt'
-		func(filename)
+		self._run(func, filename)
 		err_num = self.mockLog.printRemainingErrors()
 		self.assertEqual(err_num, 1)
 

--- a/tests/dictzip_test.py
+++ b/tests/dictzip_test.py
@@ -8,8 +8,6 @@ from glossary_errors_test import TestGlossaryErrorsBase
 
 from pyglossary.os_utils import _dictzip, _idzip
 
-FUNC_TYPE = Callable[[str], bool]
-
 TEXT = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
@@ -21,14 +19,14 @@ culpa qui officia deserunt mollit anim id est laborum.
 
 
 class TestDictzipBase(TestGlossaryErrorsBase):
-	def _run(self, func: FUNC_TYPE, filename: str | Path) -> None:
+	def _run(self, func: Callable[[str], bool], filename: str | Path) -> None:
 		done = func(str(filename))
 		if not done:
 			self.skipTest(f'Missing dependency for {func.__name__}')
 
 
 class TestDictzip(TestDictzipBase):
-	def make_dz(self, func: FUNC_TYPE, path: str | Path) -> Path:
+	def make_dz(self, func: Callable[[str], bool], path: str | Path) -> Path:
 		"""Get path of dzipped file contains TEXT."""
 		test_file_path = Path(path)/"test_file.txt"
 		result_file_path = test_file_path.parent/(test_file_path.name + ".dz")
@@ -37,13 +35,13 @@ class TestDictzip(TestDictzipBase):
 		self._run(func, test_file_path)
 		return result_file_path
 
-	def is_compressed_exists(self, func: FUNC_TYPE) -> None:
+	def is_compressed_exists(self, func: Callable[[str], bool]) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			result_file_path = self.make_dz(func, tmp_dir)
 			self.assertTrue(result_file_path.exists())
 			self.assertTrue(result_file_path.is_file())
 
-	def is_compressed_matches(self, func: FUNC_TYPE) -> None:
+	def is_compressed_matches(self, func: Callable[[str], bool]) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			result_file_path = self.make_dz(func, tmp_dir)
 			with gzip.open(result_file_path, 'r') as file:
@@ -62,7 +60,7 @@ class TestDictzipErrors(TestDictzipBase):
 		self.mockLog.clear()
 		super().tearDown()
 
-	def on_missing_target(self, func: FUNC_TYPE) -> None:
+	def on_missing_target(self, func: Callable[[str], bool]) -> None:
 		filename = '/NOT_EXISTED_PATH/file.txt'
 		self._run(func, filename)
 		err_num = self.mockLog.printRemainingErrors()

--- a/tests/g_aard2_slob_test.py
+++ b/tests/g_aard2_slob_test.py
@@ -22,7 +22,7 @@ class TestGlossarySlob(TestGlossaryBase):
 			"100-en-fa-res.slob": "0216d006",
 			"100-en-fa-res-slob.txt": "c73100b3",
 			"100-en-fa-res-slob-sort.txt": "8253fe96",
-            "300-ru-en.txt": "77cfee2f",
+			"300-ru-en.txt": "77cfee2f",
 		})
 
 	def setUp(self):


### PR DESCRIPTION
Update on #512 which had not been completed.

### Changes
- Fix catching `dictzip` stderr
- Test both `idzip` and `dictzip` branches
- Dictzip test cases will be skipped on environment with no appropriate dependencies (such as CI)

### Further suggestions
- Append `python-idzip` to `extra_required` (`full`?) in the `setup.py`
- Get an error when the `dictzip=True` is passed to the stardict writer and files are not compresses because of missing dependencies. In such case compression may be conditional when no explicit `dictzip` value by a user.
- Seems `python_requires` of the `setup.py` should be increased to `>=3.10` since code contains `TypeA | TypeB` style unions ([which had been introduced in 3.10](https://docs.python.org/3/library/typing.html#typing.Union))