### PR TITLE
Treat alternative headword as Slob alias

### DIFF
--- a/pyglossary/plugins/aard2_slob.py
+++ b/pyglossary/plugins/aard2_slob.py
@@ -345,26 +345,23 @@ class Writer:
 			else:
 				_ctype = "text/plain; charset=utf-8"
 
-		if not self._separate_alternates:
-			writer.add(
-				b_defi,
-				*tuple(words),
-				content_type=_ctype,
-			)
-			return
-
 		headword, *alts = words
 		writer.add(
 			b_defi,
 			headword,
 			content_type=_ctype,
 		)
-		for alt in alts:
-			writer.add(
-				b_defi,
-				f"{alt}, {headword}",
-				content_type=_ctype,
-			)
+
+		if self._separate_alternates:
+			for alt in alts:
+				writer.add(
+					b_defi,
+					f"{alt}, {headword}",
+					content_type=_ctype,
+				)
+		else:
+			for alt in alts:
+				writer.add_alias(alt, headword)
 
 	def write(self) -> "Generator[None, EntryType, None]":
 		slobWriter = self._slobWriter


### PR DESCRIPTION
There is problem when I convert from AppleDict -> Slob:
* If I don't add alts to Slob at all, the size of the Slob file is 7 MiB
* If I add alts using `writer.add_alias()`, the size of the Slob file is 73 MiB

I think, that aliases should not increase the size of the file manifold. I tried to fix this with this PR and treat alts as aliases by using `writer.add_alias()`. But for some reason it still doesn't really work. What could be the problem here?

Is `add_alias()` supposed to increase the size of Slob file, @itkach? Files can be [seen here](https://mega.nz/folder/elwgBDzC#qLRuACGNkXqyiEq7oeG8Nw).