### PR TITLE
Improve rendering of XDXF

### DIFF
--- a/pyglossary/plugins/xdxf/__init__.py
+++ b/pyglossary/plugins/xdxf/__init__.py
@@ -43,6 +43,7 @@ from pyglossary.option import (
 	Option,
 )
 from pyglossary.text_utils import toStr
+from lxml import etree as ET
 
 __all__ = [
 	"Reader",
@@ -79,7 +80,6 @@ optionsProp: "dict[str, Option]" = {
 	),
 }
 
-
 """
 new format
 <xdxf ...>
@@ -110,9 +110,7 @@ old format
 </xdxf>
 """
 
-
 if TYPE_CHECKING:
-
 	class TransformerType(typing.Protocol):
 		def transform(self, article: "Element") -> str: ...
 
@@ -125,6 +123,9 @@ class Reader:
 
 	_html: bool = True
 	_xsl: bool = False
+	_has_added_css: bool = False
+	_abbr_defs_js: bytes = None
+	_has_added_js: bool = False
 
 	infoKeyMap = {
 		"full_name": "name",
@@ -154,7 +155,6 @@ class Reader:
 
 	def open(self, filename: str) -> None:  # noqa: PLR0912
 		# <!DOCTYPE xdxf SYSTEM "http://xdxf.sourceforge.net/xdxf_lousy.dtd">
-		from lxml import etree as ET
 
 		self._filename = filename
 		if self._html:
@@ -175,12 +175,14 @@ class Reader:
 			cfile,
 			events=("end",),
 		)
+		abbr_defs = []
 		for _, _elem in context:
 			elem = cast("Element", _elem)
 			if elem.tag in {"meta_info", "ar", "k", "abr", "dtrn"}:
 				break
 			# every other tag before </meta_info> or </ar> is considered info
 			if elem.tag == "abbr_def":
+				abbr_defs.append(elem)
 				continue
 			# in case of multiple <from> or multiple <to> tags, the last one
 			# will be stored.
@@ -203,7 +205,7 @@ class Reader:
 				continue
 			key = self.infoKeyMap.get(elem.tag, elem.tag)
 			self._glos.setInfo(key, elem.text)
-
+		self._abbr_defs_js = self.generate_abbr_js(abbr_defs)
 		del context
 
 		if cfile.seekable():
@@ -220,14 +222,21 @@ class Reader:
 		return 0
 
 	def __iter__(self) -> "Iterator[EntryType]":
-		from lxml import etree as ET
-		from lxml.etree import tostring
-
 		context = ET.iterparse(  # type: ignore
 			self._file,
 			events=("end",),
 			tag="ar",
 		)
+
+		if self._has_added_css is False:
+			self._has_added_css = True
+			with open('pyglossary/xdxf/xdxf.css', 'rb') as css_file:
+				yield self._glos.newDataEntry('css/xdxf.css', css_file.read())
+
+		if self._abbr_defs_js is not None and not self._has_added_js:
+			self._has_added_js = True
+			yield self._glos.newDataEntry('js/xdxf.js', self._abbr_defs_js)
+
 		for _, _article in context:
 			article = cast("Element", _article)
 			article.tail = None
@@ -238,10 +247,11 @@ class Reader:
 				if len(words) == 1:
 					defi = self._re_span_k.sub("", defi)
 			else:
-				b_defi = cast(bytes, tostring(article, encoding=self._encoding))
+				b_defi = cast(bytes, ET.tostring(article, encoding=self._encoding))
 				defi = b_defi[4:-5].decode(self._encoding).strip()
 				defiFormat = "x"
 
+			defi = f"""<!DOCTYPE html><html><head><link rel="stylesheet" href="css/xdxf.css"/></head><body>{defi}<script type="text/javascript" src="js/xdxf.js"></script></body></html>"""
 			# log.info(f"{defi=}, {words=}")
 			yield self._glos.newEntry(
 				words,
@@ -261,12 +271,27 @@ class Reader:
 		self._file.close()
 		self._file = nullBinaryIO
 
+	def generate_abbr_js(self, abbr_defs: typing.List["Element"]) -> bytes:
+		abbr_map_js = """const abbr_map = new Map();\n"""
+		for abbr_def in abbr_defs:
+			abbr_k_list: typing.List[str] = []
+			abbr_v_text = ""
+			for child in abbr_def.xpath("child::node()"):
+				if child.tag == 'abbr_k':
+					abbr_k_list.append(self._htmlTr.stringify_children(child))
+				if child.tag == 'abbr_v':
+					abbr_v_text = self._htmlTr.stringify_children(child)
+			# TODO escape apostrophes
+			for abbr_k in abbr_k_list:
+				if len(abbr_k) > 0 and len(abbr_v_text) > 0:
+					abbr_map_js += f"abbr_map.set('{abbr_k}', '{abbr_v_text}');\n"
+		with open('pyglossary/xdxf/xdxf.js', 'rb') as js_file:
+			return abbr_map_js.encode(encoding='utf-8') + js_file.read()
+
 	@staticmethod
 	def tostring(
 		elem: "Element",
 	) -> str:
-		from lxml import etree as ET
-
 		return (
 			ET.tostring(
 				elem,

--- a/pyglossary/xdxf/transform.py
+++ b/pyglossary/xdxf/transform.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
 	from pyglossary.lxml_types import Element, T_htmlfile
 
-
 log = logging.getLogger("pyglossary")
 
 __all__ = [
@@ -14,13 +13,12 @@ __all__ = [
 
 
 class XdxfTransformer:
-	_gram_color: str = "green"
-	_example_padding: int = 10
-
 	def __init__(self, encoding: str = "utf-8") -> None:
 		self._encoding = encoding
+		self.logging_enabled = False
 		self._childTagWriteMapping = {
 			"br": self._write_br,
+			"u": self._write_basic_format,
 			"i": self._write_basic_format,
 			"b": self._write_basic_format,
 			"sub": self._write_basic_format,
@@ -38,6 +36,7 @@ class XdxfTransformer:
 			"iref": self._write_iref,
 			"pos": self._write_pos,
 			"abr": self._write_abr,
+			"abbr": self._write_abbr,
 			"dtrn": self._write_dtrn,
 			"co": self._write_co,
 			"c": self._write_c,
@@ -45,13 +44,11 @@ class XdxfTransformer:
 			"def": self._write_def,
 			"deftext": self._write_deftext,
 			"span": self._write_span,
-			"abbr_def": self._write_abbr_def,
 			"gr": self._write_gr,
 			"ex_orig": self._write_ex_orig,
 			"categ": self._write_categ,
 			"opt": self._write_opt,
 			"img": self._write_img,
-			"abbr": self._write_abbr,
 			"etm": self._write_etm,
 		}
 
@@ -125,11 +122,10 @@ class XdxfTransformer:
 			if not hasPrev:
 				child = child.lstrip()
 		elif child.startswith("\n"):
-			child = child.lstrip()
+			# child = child.lstrip()
 			if hasPrev:
 				addSep()
 
-		child = child.rstrip()
 		lines = [line for line in child.split("\n") if line]
 		for index, line in enumerate(lines):
 			if index > 0:
@@ -144,10 +140,7 @@ class XdxfTransformer:
 		stringSep = " "
 		with hf.element(
 			"div",
-			attrib={
-				"class": "example",
-				"style": f"padding: {self._example_padding}px 0px;",
-			},
+			attrib={"class": elem.tag},
 		):
 			for child in elem.xpath("child::node()"):
 				if isinstance(child, str):
@@ -159,13 +152,36 @@ class XdxfTransformer:
 					with hf.element("div"):
 						self._write_iref(hf, child)  # NESTED 5
 					continue
-				if child.tag in {"ex_orig", "ex_tran"}:
-					with hf.element("div"):
-						self.writeChildrenOf(hf, child, stringSep=stringSep)  # NESTED 5
+
+				if child.tag == "ex_orig":
+					with hf.element("span", attrib={"class": child.tag}):
+						self.writeChildrenOf(hf, child, stringSep=stringSep)
+					continue
+				if child.tag == "ex_tran":
+					ex_trans = elem.xpath('./ex_tran')
+					if ex_trans.index(child) == 0:
+						if len(ex_trans) > 1:
+							# when we have several translations, make an HTML unordered list for them
+							with hf.element("ul", attrib={}):
+								for ex_tran in ex_trans:
+									with hf.element("li", attrib={}):
+										self._write_ex_transl(hf, ex_tran)
+						else:
+							self._write_ex_transl(hf, child)
 					continue
 				# log.warning(f"unknown tag {child.tag} inside <ex>")
 				self.writeChild(hf, child, elem, prev, stringSep=stringSep)
 				prev = child
+
+	def _write_ex_orig(self, hf: "T_htmlfile", child: "Element") -> None:
+		# TODO NOT REACHABLE
+		quit("NOT REACHABLE")
+		with hf.element("i"):
+			self.writeChildrenOf(hf, child)
+
+	def _write_ex_transl(self, hf: "T_htmlfile", child: "Element") -> None:
+		with hf.element("span", attrib={"class": child.tag}):
+			self.writeChildrenOf(hf, child)
 
 	def _write_iref(self, hf: "T_htmlfile", child: "Element") -> None:
 		iref_url = child.attrib.get("href", "")
@@ -203,18 +219,24 @@ class XdxfTransformer:
 		hf.write(ET.Element("br"))
 
 	def _write_k(self, hf: "T_htmlfile", child: "Element") -> None:
-		with hf.element("div", attrib={"class": child.tag}):
-			# with hf.element(glos.titleTag(child.text)):
-			# ^ no glos object here!
-			with hf.element("b"):
+		self.logging_enabled = child.text == "iść"
+
+		index = child.getparent().index(child)
+		if index == 0:
+			with (hf.element("div", attrib={"class": child.tag})):
+				# with hf.element(glos.titleTag(child.text)):
+				# ^ no glos object here!
+				self.writeChildrenOf(hf, child)
+		else:
+			with (hf.element("span", attrib={"class": child.tag})):
+				hf.write(str(index))
 				self.writeChildrenOf(hf, child)
 
 	def _write_mrkd(self, hf: "T_htmlfile", child: "Element") -> None:  # noqa: PLR6301
 		if not child.text:
 			return
 		with hf.element("span", attrib={"class": child.tag}):
-			with hf.element("b"):
-				hf.write(child.text)
+			hf.write(child.text)
 
 	def _write_kref(self, hf: "T_htmlfile", child: "Element") -> None:
 		if not child.text:
@@ -235,21 +257,24 @@ class XdxfTransformer:
 
 	def _write_pos(self, hf: "T_htmlfile", child: "Element") -> None:
 		with hf.element("span", attrib={"class": child.tag}):
-			with hf.element("font", color="green"):
-				with hf.element("i"):
-					self.writeChildrenOf(hf, child)  # NESTED 5
+			self.writeChildrenOf(hf, child)
 
 	def _write_abr(self, hf: "T_htmlfile", child: "Element") -> None:
+		with hf.element("span", attrib={"class": 'abbr'}):
+			self.writeChildrenOf(hf, child)
+
+	def _write_abbr(self, hf: "T_htmlfile", child: "Element") -> None:  # noqa: PLR6301
 		with hf.element("span", attrib={"class": child.tag}):
-			with hf.element("font", color="green"):
-				with hf.element("i"):
-					self.writeChildrenOf(hf, child)  # NESTED 5
+			self.writeChildrenOf(hf, child)
 
 	def _write_dtrn(self, hf: "T_htmlfile", child: "Element") -> None:
 		self.writeChildrenOf(hf, child, sep=" ")
 
 	def _write_co(self, hf: "T_htmlfile", child: "Element") -> None:
-		self.writeChildrenOf(hf, child, sep=" ")
+		with hf.element("span", attrib={"class": child.tag}):
+			hf.write("(")
+			self.writeChildrenOf(hf, child, sep=" ")
+			hf.write(")")
 
 	def _write_basic_format(self, hf: "T_htmlfile", child: "Element") -> None:
 		with hf.element(child.tag):
@@ -273,38 +298,44 @@ class XdxfTransformer:
 			log.warning(f"rref with no text: {self.tostring(child)}")
 			return
 
-	def _write_def(self, hf: "T_htmlfile", child: "Element") -> None:
-		# TODO: create a list (ol / ul) unless it has one item only
-		# like FreeDict reader
-		with hf.element("div"):
-			self.writeChildrenOf(hf, child)
+	def _write_def(self, hf: "T_htmlfile", elem: "Element") -> None:
+		has_nested_def = False
+		has_deftext = False
+		for child in elem.iterchildren():
+			if child.tag == 'def':
+				has_nested_def = True
+			if child.tag == 'deftext':
+				has_deftext = True
+
+		if elem.getparent().tag == 'ar':  # this is a root <def>
+			if has_nested_def:
+				with hf.element("ol"):
+					self.writeChildrenOf(hf, elem)
+			else:
+				with hf.element("div"):
+					self.writeChildrenOf(hf, elem)
+		elif has_deftext:
+			with hf.element("li"):
+				self.writeChildrenOf(hf, elem)
+		elif has_nested_def:
+			with hf.element("li"):
+				with hf.element("ol"):
+					self.writeChildrenOf(hf, elem)
+		else:
+			with hf.element("li"):
+				self.writeChildrenOf(hf, elem)
 
 	def _write_deftext(self, hf: "T_htmlfile", child: "Element") -> None:
-		self.writeChildrenOf(hf, child, stringSep=" ", sep=" ")
+		with hf.element("span", attrib={"class": child.tag}):
+			self.writeChildrenOf(hf, child, stringSep=" ", sep=" ")
 
 	def _write_span(self, hf: "T_htmlfile", child: "Element") -> None:
 		with hf.element("span"):
 			self.writeChildrenOf(hf, child)
 
-	def _write_abbr_def(self, hf: "T_htmlfile", child: "Element") -> None:
-		# _type = child.attrib.get("type", "")
-		# {"": "", "grm": "grammatical", "stl": "stylistical",
-		#  "knl": "area/field of knowledge", "aux": "subsidiary"
-		#  "oth": "others"}[_type]
-		self.writeChildrenOf(hf, child)
-
 	def _write_gr(self, hf: "T_htmlfile", child: "Element") -> None:
-		from lxml import etree as ET
-
-		with hf.element("font", color=self._gram_color):
-			hf.write(child.text or "")
-		hf.write(ET.Element("br"))
-
-	def _write_ex_orig(self, hf: "T_htmlfile", child: "Element") -> None:
-		with hf.element("i"):
+		with hf.element("div", attrib={"class": child.tag}):
 			self.writeChildrenOf(hf, child)
-
-	# def _write_ex_transl(self, hf: "T_htmlfile", child: "Element") -> None:
 
 	def _write_categ(self, hf: "T_htmlfile", child: "Element") -> None:
 		with hf.element("span", style="background-color: green;"):
@@ -319,11 +350,6 @@ class XdxfTransformer:
 	def _write_img(self, hf: "T_htmlfile", child: "Element") -> None:  # noqa: PLR6301
 		with hf.element("img", attrib=dict(child.attrib)):
 			pass
-
-	def _write_abbr(self, hf: "T_htmlfile", child: "Element") -> None:  # noqa: PLR6301
-		# FIXME: may need an space or newline before it
-		with hf.element("i"):
-			hf.write(f"{child.text}")
 
 	def _write_etm(self, hf: "T_htmlfile", child: "Element") -> None:  # noqa: PLR6301
 		# Etymology (history and origin)
@@ -364,17 +390,15 @@ class XdxfTransformer:
 		stringSep: "str | None" = None,
 	) -> None:
 		if isinstance(child, str):
-			if not child.strip():
-				return
 			self.writeString(hf, child, parent, prev, stringSep=stringSep)
-			return
-		self.writeChildElem(
-			hf=hf,
-			child=child,
-			parent=parent,
-			prev=prev,
-			stringSep=stringSep,
-		)
+		else:
+			self.writeChildElem(
+				hf=hf,
+				child=child,
+				parent=parent,
+				prev=prev,
+				stringSep=stringSep,
+			)
 
 	def shouldAddSep(  # noqa: PLR6301
 		self,
@@ -407,6 +431,22 @@ class XdxfTransformer:
 				hf.write(sep)
 			self.writeChild(hf, child, elem, prev, stringSep=stringSep)
 			prev = child
+
+	@staticmethod
+	def stringify_children(elem: "Element") -> str:
+		from lxml.etree import tostring
+		from itertools import chain
+		children = [chunk for chunk in chain(
+				(elem.text,),
+				chain(*((tostring(child, with_tail=False), child.tail) for child in elem.getchildren())),
+				(elem.tail,)) if chunk]
+		normalized_children = ""
+		for chunk in children:
+			if isinstance(chunk, str):
+				normalized_children += chunk
+			if isinstance(chunk, bytes):
+				normalized_children += chunk.decode(encoding='utf-8')
+		return normalized_children
 
 	def transform(self, article: "Element") -> str:
 		from lxml import etree as ET

--- a/pyglossary/xdxf/xdxf.css
+++ b/pyglossary/xdxf/xdxf.css
@@ -1,0 +1,75 @@
+div.k {
+    font-weight: 700;
+    font-size: 150%;
+}
+
+span.k {
+    font-size: 100%;
+}
+
+.gr {
+    color: green;
+}
+
+ol {
+    list-style-type: decimal;
+    padding-left: 20px;
+}
+
+ol > li > ol > li > ol {
+    list-style-type: lower-latin;
+}
+
+.ex {
+    margin: 0px 0px 0px 20px;
+    color: #888888;
+}
+
+.ex i {
+    color: red;
+}
+
+.ex_orig {
+    font-weight: 700;
+}
+
+.ex_tran {
+    /* TODO remove */
+    color: #008888;
+}
+
+.ex .mrkd {
+    text-decoration: underline;
+}
+
+.co {
+    color: #888888;
+    font-style: italic;
+}
+
+.abbr {
+    color: green;
+    font-style: italic;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+}
+
+.pos {
+    color: red;
+    font-style: italic;
+}
+
+.abbr_popup {
+  background: #feffca;
+  border: 1px solid rgba(0,0,0,.15);
+  border-radius: 2px;
+  box-shadow: 2px 2px 3px rgba(0,0,0,.1),0 2px 0 rgba(255,255,255,.4) inset,0 -2px 0 rgba(242,85,0,1) inset;
+  cursor: pointer;
+  display: none;
+  font-size: 100%;
+  font-style: normal;
+  padding: .05em .6em .2em;
+  position: absolute;
+  z-index: 999;
+  margin-bottom: 100px;
+}

--- a/pyglossary/xdxf/xdxf.js
+++ b/pyglossary/xdxf/xdxf.js
@@ -1,0 +1,56 @@
+
+prepare_tooltips()
+
+// iterate over all tags that can show tooltip
+function prepare_tooltips() {
+    var pos_elems = document.querySelectorAll(".pos");
+    var abbr_elems = document.querySelectorAll(".abbr");
+    iterate_over_abbr_elems(pos_elems)
+    iterate_over_abbr_elems(abbr_elems)
+}
+
+function iterate_over_abbr_elems(elems) {
+    for (var i = 0; i < elems.length; i++) {
+        var elem = elems[i];
+        if (abbr_map.has(elem.textContent)) {
+            elem.classList.add("abbr");
+            elem.classList.remove("pos");
+            elem.addEventListener("mouseover", show_popup);
+            elem.addEventListener("mouseout", hide_popup);
+        } else {
+            elem.classList.add("pos");
+            elem.classList.remove("abbr");
+        }
+    }
+}
+
+function show_popup(event) {
+    var pos_elem = event.target
+    var pos_text = pos_elem.textContent
+    var s = document.createElement("small");
+    s.classList.add("abbr_popup");
+    s.innerHTML = abbr_map.get(pos_text)
+    pos_elem.parentNode.insertBefore(s, pos_elem.nextSibling);
+
+    if (s.offsetWidth > 200) {
+        if ((pos_elem.offsetLeft + 200) > document.body.offsetWidth) {
+            s.style.left = pos_elem.offsetLeft - ((pos_elem.offsetLeft + 200) - document.body.offsetWidth) + 'px';
+        } else {
+            s.style.left = pos_elem.offsetLeft + 'px';
+        }
+    } else {
+        if ((pos_elem.offsetLeft + s.offsetWidth) > document.body.offsetWidth) {
+            s.style.left = pos_elem.offsetLeft - ((pos_elem.offsetLeft + s.offsetWidth) - document.body.offsetWidth) + 'px';
+        } else {
+            s.style.left = pos_elem.offsetLeft + 'px';
+        }
+    }
+    s.style.display = 'block';
+}
+
+function hide_popup(event) {
+    var popups = document.getElementsByClassName('abbr_popup');
+    for (var i = 0; i < popups.length; ++i) {
+        popups[i].remove();
+    }
+}

--- a/pyglossary/xdxf/xdxf.xsl
+++ b/pyglossary/xdxf/xdxf.xsl
@@ -27,6 +27,12 @@
     </div>
   </xsl:template>
 
+  <xsl:template match="def">
+    <div class="def">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
   <xsl:template match="br">
     <br/>
   </xsl:template>
@@ -48,7 +54,7 @@
   </xsl:template>
 
   <xsl:template match="k">
-    <span class="k"><b><xsl:apply-templates/></b></span>
+    <span class="k" style="font-size: 150%"><b><xsl:apply-templates/></b></span>
   </xsl:template>
 
   <xsl:template match="sr">
@@ -56,7 +62,7 @@
   </xsl:template>
 
   <xsl:template match="ex">
-    <span class="example" style="padding: 10px 0px;"><xsl:apply-templates/></span>
+    <div class="ex" style="padding: 0px 0px 0px 32px; color: #888888;"><xsl:apply-templates/></div>
   </xsl:template>
 
   <xsl:template match="ex_orig">


### PR DESCRIPTION
Completed:
* created a list (ol / ul) for nested <def>s
* show js tooltips for abbreviations
* fixed showing hidden <gr>
* fixed losing spaces before XDXF tags
* add braces to <co>
* show CSS instead of inlined HTML tags for: <ex>, <pos>, <abbr>, <k>, <gr>, <mrkd>