### PR TITLE
web ui: convert options dialog, fixes #598

### DIFF
--- a/pyglossary/ui/ui_web/index.html
+++ b/pyglossary/ui/ui_web/index.html
@@ -102,6 +102,14 @@
             font-size: 2em;
             height: 2em;
         }
+        pre {
+            font-size:7px;
+            font-family: 'Fira Mono', 'Jetbrains Mono', Consolas, Monaco, Lucida Console, monospace;
+        }
+        article>textarea {
+            font-family: 'Fira Mono', 'Jetbrains Mono', Consolas, Monaco, Lucida Console, monospace;
+            font-size: smaller;
+        }
     </style>
 </head>
 
@@ -193,7 +201,7 @@
             <!-- ./ Convert -->
 
             <section>
-                <textarea rows="15" id="console" name="console-area" readonly></textarea>
+                <textarea rows="15" id="console-area" name="console-area" readonly></textarea>
             </section>
 
             <!-- Progress -->
@@ -209,8 +217,6 @@
                 <details>
                     <summary>&#9432; How to convert a dictionary?</summary>
                     <p>
-                        <!-- <ul>
-                        <li> -->
                     <ol>
                         <li>Paste the full path to a dictionary file on your local file system in the <b>Input file</b>
                             field.</li>
@@ -222,9 +228,6 @@
                         <li>Click the <b>Convert</b> button and wait for the conversion to complete. For large files the
                             operation can take several minutes.</li>
                     </ol>
-
-                    <!-- </li>
-                    </ul> -->
                     </p>
                 </details>
             </section>
@@ -248,6 +251,53 @@
         </small>
     </footer>
     <!-- ./ Footer -->
+    <!-- ConfigDialog -->
+    <dialog>
+        <article>
+          <h2>Conversion Options</h2>
+          <p>
+            Please enter valid JSON for custom conversion options.</p>
+          <p>Example config (See available options in <a target="_blank" href="https://ed-25q.pages.dev/#right=url.https://cdn.jsdelivr.net/gh/ilius/pyglossary/plugins-meta/index.json&left=url.https://y-bad.pages.dev/pyglossary-config.json">plugins options reference</a>):</p>
+          <section id="configExample">
+            <details>
+                <summary>&#x002B; Click for an example</summary>
+                <p><!--noformat-->
+                    <pre>{
+ "convertOptions": {
+  "sort": true,
+  "sortKeyName": "headword_lower:es_ES",
+  "sortEncoding": "utf-8",
+  "sqlite": true
+ },
+ "readOptions": {
+  "encoding": "utf-8",
+  "audio": true,
+  "example_color": "blue",
+  "abbrev": "hover"
+ },
+ "writeOptions": {
+  "compression": "zlib",
+  "content_type": "text/html; charset=utf-8",
+  "separate_alternates": true,
+  "word_title": true,
+  "version_info": false
+ }
+}</pre><!--noformat-->
+                </p>
+            </details>
+        </section>
+
+          <textarea id="allOptions" name="allOptions" id="" cols="30" rows="10"></textarea>
+          <footer>
+            <button id="btnOptCancel" class="secondary">
+              Cancel
+            </button>
+            <button id="btnOptOk">Confirm</button>
+          </footer>
+        </article>
+      </dialog>
+    <!-- ./ ConfigDialog -->
+
     <script>
         document.getElementById('theme-switcher').addEventListener('click', function () {
             if (this.dataset.themeSwitcher !== 'dark') {
@@ -267,6 +317,9 @@
             READ: 1,  // 0b01
             WRITE: 2, // 0b10
         };
+        const FIELD_IDS_PERSISTABLE = ['inputFilename', 'inputFormat', 'outputFilename', 'outputFormat'];
+        const KEY_PG_OPTIONS = 'pg_ALL_OPTIONS';
+
         const consoleArea = document.getElementById('console-area');
         const progressBar = document.getElementById('progress');
         const progressText = document.getElementById('progress-text');
@@ -296,7 +349,7 @@
 
             socket.addEventListener('error', (error) => {
                 msg = `WebSocket error: ${error}\n`;
-                consoleArea.value += msg;
+                consoleArea.value += `${msg}\n`;
                 console.log(msg);
             });
 
@@ -340,6 +393,8 @@
                     writeDropdown.appendChild(writeFragment);
                 }).then(() => {
                     restoreFormState();
+                }).then(() => {
+                    attachListenersPostInit();
                 })
                 .catch(error => {
                     console.error("Error populating dropdowns:", error);
@@ -352,11 +407,18 @@
             btnConv.classList.toggle('outline');
             btnConv.disabled = !btnConv.disabled;
         }
+
+        function toggleAttr(elem, attr) {
+            elem.hasAttribute(attr)
+                ? elem.removeAttribute(attr)
+                : elem.setAttribute(attr, '');
+        }
+
         function attachListeners() {
             document.querySelector('input[type="submit"]').addEventListener('click', async (event) => {
 
                 progressBar.value = 0;
-                consoleArea.value = 'Starting new conversion job. Please wait... ⏳'
+                consoleArea.value = 'Starting new conversion job. Please wait... ⏳\n';
                 const form = event.target.form;
 
                 if (form.checkValidity()) {
@@ -367,6 +429,8 @@
                     const inputFormat = form.inputFormat.value;
                     const outputFilename = form.outputFilename.value;
                     const outputFormat = form.outputFormat.value;
+                    const allOptions = JSON.parse(localStorage.getItem(KEY_PG_OPTIONS) || '{}');
+
 
                     try {
                         toggleConvertButton()
@@ -379,13 +443,16 @@
                                 inputFilename,
                                 inputFormat,
                                 outputFilename,
-                                outputFormat
+                                outputFormat,
+                                convertOptions: allOptions['convertOptions'] || {},
+                                readOptions: allOptions['readOptions'] || {},
+                                writeOptions: allOptions['writeOptions'] || {},
                             }),
                         });
 
                         if (!response.ok) {
                             const msg = `Failed to start conversion: ${response.statusText} ${response.json()}\n`
-                            consoleArea.value += msg;
+                            consoleArea.value += `${msg}\n`;
                             throw new Error(msg);
 
                         }
@@ -393,7 +460,7 @@
 
                     } catch (error) {
                         console.error('Error during conversion:', error);
-                        consoleArea.value += error;
+                        consoleArea.value += `${error}\n`;
                         toggleConvertButton();
                     }
                 }
@@ -414,20 +481,63 @@
                 consoleArea.value = 'Server stopped! Window can now be closed.\n\n';
             });
 
-            document.getElementById("inputFilename").addEventListener('change', () => {
-                autoDetectFormatFromFilePath("inputFilename", 'inputFormat');
-            });
-
-            document.getElementById("outputFilename").addEventListener('change', () => {
-                autoDetectFormatFromFilePath("outputFilename", 'outputFormat');
-            });
-
             document.getElementById('btnOptions').addEventListener('click', (evt) => {
                 evt.preventDefault();
                 evt.stopImmediatePropagation();
-                consoleArea.value += 'TODO: Not implemented!';
+                const optionsDialog = document.querySelector('dialog');
+                toggleAttr(optionsDialog, 'open');
+
+                const allOptions = localStorage.getItem(KEY_PG_OPTIONS);
+
+                if (allOptions) {
+                    document.getElementById("allOptions").value = JSON.stringify(JSON.parse(allOptions), null, 1);
+                }
             });
 
+            document.getElementById('btnOptOk').addEventListener('click', (evt) => {
+                evt.preventDefault();
+                evt.stopImmediatePropagation();
+                const optionsDialog = document.querySelector('dialog');
+                // if nothing was entered then set to empty object
+                const allOptions = document.getElementById("allOptions").value || "{}";
+                try {
+                    const allOptionsObj = JSON.parse(allOptions);
+                    localStorage.setItem(KEY_PG_OPTIONS, JSON.stringify(allOptionsObj))
+                    consoleArea.value += `options saved ✔️\n${allOptions}\n`;
+                } catch (error) {
+                    console.error('Invalid JSON string:', error.message);
+                    consoleArea.value += `invalid options ${error.message} JSON\n`;
+                }
+
+                toggleAttr(optionsDialog, 'open');
+
+            });
+
+            document.getElementById('btnOptCancel').addEventListener('click', (evt) => {
+                evt.preventDefault();
+                evt.stopImmediatePropagation();
+                const optionsDialog = document.querySelector('dialog');
+                toggleAttr(optionsDialog, 'open');
+                consoleArea.value += 'options dialog cancelled without saving\n';
+            });
+
+            FIELD_IDS_PERSISTABLE.forEach(fieldId => {
+                const el = document.getElementById(fieldId);
+                el.addEventListener('change', () => {
+
+                    localStorage.setItem(`pg_${fieldId}`, el.value);
+                });
+            });
+        }
+
+        function attachListenersPostInit() {
+            document.getElementById("inputFilename").oninput = () => {
+                getFormatFromPath("inputFilename", 'inputFormat');
+            };
+
+            document.getElementById("outputFilename").oninput = () => {
+                getFormatFromPath("outputFilename", 'outputFormat');
+            };
         }
 
         const findFormatByExtension = (formats, ext) => {
@@ -436,38 +546,26 @@
             }
         };
 
-        function autoDetectFormatFromFilePath(sourceFieldId, targetFieldId) {
+        function getFormatFromPath(sourceFieldId, targetFieldId) {
             if (window.formats) {
                 const extension = document.getElementById(sourceFieldId).value.split('.').pop().toLowerCase();
                 const dictFormat = findFormatByExtension(window.formats, `.${extension}`);
                 if (dictFormat) {
                     document.getElementById(targetFieldId).value = dictFormat;
+                    localStorage.setItem(`pg_${targetFieldId}`, dictFormat);
                 }
             }
         }
 
-        function getInputValue(el) {
-            return el.tagName === 'SELECT' ? el.selectedIndex : el.value;
-        }
-
-        function setInputValue(el, val) {
-            el.tagName === 'SELECT' ? el.selectedIndex = val : el.value = val;
-        }
 
         function restoreFormState() {
-            ['inputFilename', 'inputFormat', 'outputFilename', 'outputFormat'].forEach(eid => {
-
-                const el = document.getElementById(eid);
-                const savedValue = localStorage.getItem(`pg_${eid}`);
-                console.log(eid, savedValue, el);
+            FIELD_IDS_PERSISTABLE.forEach(fieldId => {
+                const el = document.getElementById(fieldId);
+                const savedValue = localStorage.getItem(`pg_${fieldId}`);
 
                 if (savedValue) {
-                    setInputValue(el, savedValue);
+                    el.value = savedValue;
                 }
-
-                el.addEventListener('change', () => {
-                    localStorage.setItem(`pg_${eid}`, getInputValue(el));
-                });
             });
         }
 

--- a/pyglossary/ui/ui_web/server_ws_http.py
+++ b/pyglossary/ui/ui_web/server_ws_http.py
@@ -181,7 +181,6 @@ class API:
 
 
 class HttpWebsocketServer(ThreadingMixIn, HTTPServer, API, logging.Handler):
-
 	"""
 		A websocket server waiting for clients to connect.
 
@@ -467,12 +466,7 @@ class HTTPWebSocketHandler(SimpleHTTPRequestHandler):
 				self.wfile.write(json.dumps(error_message).encode())
 				return
 
-			self.server.ui_controller.start_convert_job(
-				inputFilename=payload["inputFilename"],
-				inputFormat=payload["inputFormat"],
-				outputFilename=payload["outputFilename"],
-				outputFormat=payload["outputFormat"],
-			)
+			self.server.ui_controller.start_convert_job(payload)
 
 			self.send_response(HTTPStatus.OK)
 			self.send_header("Content-type", "text/html")

--- a/pyglossary/ui/ui_web/server_ws_http.py
+++ b/pyglossary/ui/ui_web/server_ws_http.py
@@ -181,6 +181,7 @@ class API:
 
 
 class HttpWebsocketServer(ThreadingMixIn, HTTPServer, API, logging.Handler):
+
 	"""
 		A websocket server waiting for clients to connect.
 

--- a/pyglossary/ui/ui_web/ui_controller.py
+++ b/pyglossary/ui/ui_web/ui_controller.py
@@ -67,14 +67,16 @@ class WebUI(UIBase):
 
 		return True
 
-	def start_convert_job(
-		self,
-		inputFilename: str,
-		outputFilename: str,
-		inputFormat: str,
-		outputFormat: str,
-	) -> bool:
+	def start_convert_job(self, payload) -> bool:
 		glos = Glossary(ui=self)
+
+		self.inputFilename = payload.get("inputFilename")
+		self.inputFormat = payload.get("inputFormat")
+		self.outputFilename = payload.get("outputFilename")
+		self.outputFormat = payload.get("outputFormat")
+		self.readOptions = payload.get("readOptions") or self.readOptions
+		self.writeOptions = payload.get("writeOptions") or self.writeOptions
+		self.convertOptions = payload.get("convertOptions") or self.convertOptions
 
 		try:
 			log.debug(f"readOptions: {self.readOptions}")
@@ -89,13 +91,13 @@ class WebUI(UIBase):
 
 			finalOutputFile = glos.convert(
 				ConvertArgs(
-					inputFilename=inputFilename,
-					outputFilename=outputFilename,
-					inputFormat=inputFormat,
-					outputFormat=outputFormat,
+					inputFilename=self.inputFilename,
+					inputFormat=self.inputFormat,
+					outputFilename=self.outputFilename,
+					outputFormat=self.outputFormat,
 					readOptions=self.readOptions,
 					writeOptions=self.writeOptions,
-					# **self.convertOptions,
+					**self.convertOptions,
 				),
 			)
 			if finalOutputFile:


### PR DESCRIPTION
## Add convert options dialog

fixes #598

- add dialog for setting `convertOptions`, `readOptions` and `writeOptions` via JSON of the form

```json
{
  "convertOptions": {
    "sort": true,
    "sortKeyName": "headword_lower:es_ES",
    "sortEncoding": "utf-8",
    "sqlite": true
  },
  "readOptions": {
    "encoding": "utf-8",
    "audio": true,
    "example_color": "blue",
    "abbrev": "hover"
  },
  "writeOptions": {
    "compression": "zlib",
    "content_type": "text/html; charset=utf-8",
    "separate_alternates": true,
    "word_title": true,
    "version_info": false
  }
}
```