### PR TITLE
ui_web/server_ws_http.py: fix f-string error with python3.10

### DIFF
--- a/pyglossary/ui/ui_web/server_ws_http.py
+++ b/pyglossary/ui/ui_web/server_ws_http.py
@@ -385,8 +385,7 @@ class HTTPWebSocketHandler(SimpleHTTPRequestHandler):
 		WRITE = 2  # 10
 		conversion_config = {
 			name: {
-				"desc": f"{plug.description}{(plug.ext not in plug.description
-					and " (" + plug.ext + ")") or ""}",
+				"desc": plug.description,
 				"can": (READ * plug.canRead) | (WRITE * plug.canWrite),
 				"ext": plug.ext,
 			}


### PR DESCRIPTION
fix unsupported f-string error in python 3.10 in `ui_web/server_ws_http.py`

```bash
    from pyglossary.ui.ui_web.server_ws_http import create_server
  File "pyglossary-glo/pyglossary/ui/ui_web/server_ws_http.py", line 388
    				"desc": f"{plug.description}{(plug.ext not in plug.description
    				        ^
SyntaxError: unterminated string literal (detected at line 388)
```