### PR TITLE
slob writer: add opus, oga extensions

### DIFF
--- a/pyglossary/plugins/aard2_slob/writer.py
+++ b/pyglossary/plugins/aard2_slob/writer.py
@@ -56,6 +56,8 @@ class Writer:
 		"otf": "application/x-font-opentype",
 		"mp3": "audio/mpeg",
 		"ogg": "audio/ogg",
+		"opus": "audio/ogg",
+		"oga": "audio/ogg",
 		"spx": "audio/x-speex",
 		"wav": "audio/wav",
 		"ini": "text/plain",


### PR DESCRIPTION
For slob writer add `.opus`, `.oga` extensions for mime type `audio/ogg`

Reference:
- https://wiki.xiph.org/MIME_Types_and_File_Extensions#.opus_-_audio/ogg

Dictionaries containing ogg audio with `.opus` format are causing errors like below:

```ini
[ERROR] Aard2 slob: unknown content type for 'es/zenorio/sobredimensión.opus'
```