### PR TITLE
feat: more kindlgen arguments

### DIFF
--- a/pyglossary/plugins/ebook_mobi/writer.py
+++ b/pyglossary/plugins/ebook_mobi/writer.py
@@ -294,6 +294,8 @@ xmlns:oebpackage="http://openebook.org/namespaces/oeb-package/1.0/">
 			kindlegen_path,
 			join(filename, "OEBPS", "content.opf"),
 			"-gen_ff_mobi7",
+			"-dont_append_source",
+			"-verbose",
 			"-o",
 			"content.mobi",
 		]


### PR DESCRIPTION
- `-dont_append_source` to create smaller files by not including source files in the final dict
- `-verbose` to help debug issues on failure

Closes #627.
Supersed #628.