### PR TITLE
freedict: fix adding inflections as keywords

### DIFF
--- a/pyglossary/plugins/freedict/reader.py
+++ b/pyglossary/plugins/freedict/reader.py
@@ -622,7 +622,7 @@ class Reader(ReaderUtils):
 
 		inflectedKeywords: list[str] = []
 
-		for form in entry.findall("form", _NAMESPACE):
+		for form in entry.findall(".//form", _NAMESPACE):
 			inflected = form.get("type") == "infl"
 			for orth in form.findall("orth", _NAMESPACE):
 				if not orth.text:


### PR DESCRIPTION
Restores feature added in 40f00e3c that seems to have stopped working in 3e67672b.

Thanks to @karlb for pointing me in the right direction.