### PR TITLE
Wiktextract: rudimentary handler for Chinese phonology section.

### DIFF
--- a/pyglossary/plugins/wiktextract/reader.py
+++ b/pyglossary/plugins/wiktextract/reader.py
@@ -295,7 +295,7 @@ class Reader:
 
 		tagsText = " ".join(list(tags))
 		value = sound.get("ipa")
-		
+
 		with hf.element("font", color=self._pron_color):
 			hf.write(str(value))
 		hf.write(f" ({tagsText}; ipa)")


### PR DESCRIPTION
A fix to #637. While very lacking for now, might still be useful.

After the fix:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/571cd149-c6c6-4e79-93a1-44842f70139c" />
