### PR TITLE
Wiktionary: add handling for non-Unicode character 

### DIFF
--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -72,7 +72,8 @@ def processSoundList(
         "Hakka-Romanization-System": "Hakka Romanization System",
         "Guangdong-Romanization": "Guangdong",
         "Wiktionary-specific": "Wiktionary",
-        "Sinological-IPA": "ipa"
+        "Sinological-IPA": "IPA",
+        "bopomofo": "Bopomofo"
     }
 
     processedSounds = {}

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -99,9 +99,9 @@ def processSoundList(
         if not dialectText:
             dialectText = "_"
 
-        phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
         # Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
         # i.e., "uie\x06". This seem to be an error from wiktionary side.
+        phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
         if not phonText or phonText == "uie\x06":
             continue
 

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -100,8 +100,10 @@ def processSoundList(
             dialectText = "_"
 
         phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
-        if not phonText:
-            return None
+        # Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
+        # i.e., "uie\x06". This seem to be an error from wiktionary side.
+        if not phonText or phonText == "uie\x06":
+            continue
 
         if langText not in processedSounds:
             processedSounds[langText] = {dialectText: {phonSystemText: [phonText]}}


### PR DESCRIPTION
A fix to #640. Some word e.g., (鿦)[https://en.wiktionary.org/wiki/%E9%BF%A6] have non-Unicode string `uie\x06` in it. 

This PR was tested on the entire Chinese Wiktionary so this should be sufficient for now.

Edit: also fixed some spelling