### PR TITLE
Wiktionary: Fix examples section of Chinese entries 

### DIFF
--- a/pyglossary/plugins/wiktextract/reader.py
+++ b/pyglossary/plugins/wiktextract/reader.py
@@ -135,6 +135,7 @@ class Reader:
 		langCode = data.get("lang_code")
 		if lang == "Chinese" or langCode == "zh":
 			from .zh_utils import processChinese
+
 			data = processChinese(data)
 
 		for formDict in data.get("forms", []):
@@ -259,7 +260,6 @@ class Reader:
 		hf: T_htmlfile,
 		soundList: dict[str, Any] | None,
 	) -> None:
-
 		if not soundList:
 			return
 

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -4,124 +4,234 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
+	from typing import Any
+
+LANGS: tuple[str] = (
+	"Mandarin",
+	"MSC",
+	"Cantonese",
+	"Gan",
+	"Hakka",
+	"Jin",
+	"Hokkien",
+	"Shanghainese",
+	"Teochew",
+	"Leizhou",
+	"Xiang",
+	"Jian'ou",
+	"Fuzhou",
+	"Puxian-Min",
+	"Southern-Pinghua",
+	"Wu",
+	"Middle-Chinese",
+	"Old-Chinese",
+)
+
+PHON_SYSTEMS: tuple[str] = (
+	"Pinyin",
+	"Hanyu-Pinyin",
+	"bopomofo",
+	"Cyrillic",
+	"Tongyong-Pinyin",
+	"Wade-Giles",
+	"Yale",
+	"Gwoyeu-Romatsyh",
+	"Palladius",
+	"Latinxua-Sin-Wenz",
+	"Guangdong",
+	"Guangdong-Romanization",
+	"Kienning-Colloquial-Romanized",
+	"Wugniu",
+	"Jyutping",
+	"Wiktionary-specific",
+	"Phak-fa-su",
+	"PFS",
+	"Hakka-Romanization-System",
+	"Hagfa-Pinyim",
+	"POJ",
+	"Peng'im",
+	"Sinological-IPA",
+	"Foochow-Romanized",
+	"Tai-lo",
+	"Phofsit-Daibuun",
+	"Zhengzhang",
+	"Baxter-Sagart",
+)
+
+WRITTING_SYSTEMS: dict[str, str] = {
+	"Traditional Chinese": "trad.",
+	"Simplified Chinese": "simp.",
+}
 
 
-def processSoundList(
-    soundList: dict[str, Any]
-) -> dict[str, Any]:
-    # {"lang":{"dialect": {"system": ["phonatic"]}}}
-    # "_" = not found
+def processSenses(senseList: dict[str, Any]) -> list[dict[str, Any]] | None:
+	if not senseList:
+		return None
 
-    # key 'tags' contains:
-    #   - language ["Mandarin"]
-    #   - phonetic writting system ["Pinyin", "bopomofo"]
-    #   - dialag of each langauge ["standard", "Chendu", "Xi'an"]
-    #
-    # Since the order is random, the groupping is assess only by
-    # Language and phonetic writting system for simplicity
-    # Otherwise the string will be interpreted as dialect/place name
-    # Note that many item in data["sounds"] are not extracted properly
-    # in the first place, so only correctly extracted one will be rendered
+	def processExamples(exampleList: list[dict[str, Any]]) -> list[dict[str, Any]]:
+		# there are "tags" and "raw_tags" which contain language
+		# and writting system info. Usually there are 2 entries for
+		# traditional and simplified characters.
+		# the word is consider the same if both "roman" and translation is the same
 
-    LANGS: tuple[str] = (
-        "Mandarin", "Cantonese", "Gan",
-        "Hakka", "Jin", "Hokkien",
-        "Teochew", "Leizhou", "Xiang",
-        "Jian'ou", "Fuzhou", "Puxian-Min",
-        "Southern-Pinghua", "Wu",
-        "Middle-Chinese", "Old-Chinese")
+		skippedExamples = []
 
-    # might need to adding more languages in the future
-    # data from wiktextract does not provide the groupping
-    NORTHERN_MIN: tuple[str] = ("Jian'ou")  # noqa:F841
-    EASTERN_MIN: tuple[str] = ("Fuzhou")  # noqa:F841
-    SOUTHERN_MIN: tuple[str] = ("Hokkien", "Teochew", "Leizhou")  # noqa:F841
+		# {translation+phonetic: {script1: str, script2: str, ...}}
+		tempExamples = {}
+		for example in exampleList:
+			tags = example.get("tags", []) + example.get("raw_tags", [])
 
-    PHON_SYSTEMS: tuple[str] = (
-        "Pinyin", "Hanyu-Pinyin", "bopomofo", "Cyrillic",
-        "Tongyong-Pinyin", "Wade-Giles", "Yale",
-        "Gwoyeu-Romatsyh", "Palladius", "Latinxua-Sin-Wenz",
-        "Guangdong", "Guangdong-Romanization",
-        "Kienning-Colloquial-Romanized",
-        "Jyutping", "Wiktionary-specific", "Phak-fa-su", "PFS",
-        "Hakka-Romanization-System", "Hagfa-Pinyim",
-        "POJ", "Peng'im", "Sinological-IPA", "Foochow-Romanized",
-        "Tai-lo", "Phofsit-Daibuun",
-        "Zhengzhang", "Baxter-Sagart"
-    )
+			targetLang = "Translation"
+			translationText = ""
 
-    # it seem like readings without specified phonetic system have default
-    # however, i'm not so sure and the list here is based purely on
-    # wiktionary page of the character「我」
-    DEFAULT_PS = {
-        "Mandarin": "Pinyin",
-        "Cantonese": "Jyutping",
-        "Hakka": "Hakka Romanization System"
-    }
+			# Only English for now, but other languages should use different keys
+			for _lang in ["english"]:
+				if _lang in example:
+					translationText = example[_lang]
+					targetLang = _lang.capitalize()
 
-    PREFERRED_PS_NAME = {
-        "Hanyu-Pinyin": "Pinyin",
-        "Latinxua-Sin-Wenz": "Scuanxua Ladinxua Xin Wenz",
-        "Gwoyeu-Romatsyh": "Gwoyeu Romatsyh",
-        "Kienning-Colloquial-Romanized": "Kienning Colloquial Romanized",
-        "Foochow-Romanized": "Bàng-uâ-cê",
-        "Tai-lo": "Tâi-lô",
-        "Phofsit-Daibuun": "Phofsit Daibuun",
-        "PFS": "Pha̍k-fa-sṳ",
-        "Hakka-Romanization-System": "Hakka Romanization System",
-        "Guangdong-Romanization": "Guangdong",
-        "Wiktionary-specific": "Wiktionary",
-        "Sinological-IPA": "IPA",
-        "bopomofo": "Bopomofo"
-    }
+			if not tags and not translationText:
+				# Nothing to process, simply copy this example
+				skippedExamples.append(example)
+				continue
 
-    processedSounds = {}
+			lang = [t for t in tags if t in LANGS]
+			langText = lang[0] if lang else ""
 
-    for sound in soundList:
-        tags = sound.get("tags")
-        if not tags:
-            continue
+			romanSystem = [t for t in tags if t in PHON_SYSTEMS]
+			romanSystemText = romanSystem[0] if romanSystem else "Romanization"
 
-        lang = [t for t in tags if t in LANGS]
-        if not lang:
-            continue
-        langText = lang[0]
+			writtingSystem = [
+				WRITTING_SYSTEMS[t] for t in tags if t in WRITTING_SYSTEMS
+			]
+			writtingSystemText = writtingSystem[0] if writtingSystem else ""
 
-        phonSystem = [t for t in tags if t in PHON_SYSTEMS]
-        if not phonSystem:
-            phonSystem.append(DEFAULT_PS.get(langText, ""))
-        phonSystemText = ", ".join(PREFERRED_PS_NAME.get(p, p) for p in phonSystem)
-        if not phonSystemText:
-            phonSystemText = "_"
+			romanText = example.get("roman", "")
 
-        dialect = [t for t in tags if t != langText and t not in phonSystem]
-        dialectText = ", ".join(dialect)
-        if not dialectText:
-            dialectText = "_"
+			text = example.get("text", "")
+			if langText or writtingSystemText:
+				separator = ", " if langText and writtingSystemText else ""
+				text += f" ({langText}{separator}{writtingSystemText})"
 
-        # Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
-        # i.e., "uie\x06". This seem to be an error from wiktionary side.
-        phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
-        if not phonText or phonText == "uie\x06":
-            continue
+			keyText = translationText + romanText
 
-        if langText not in processedSounds:
-            processedSounds[langText] = {dialectText: {phonSystemText: [phonText]}}
-            continue
-        if dialectText not in processedSounds[langText]:
-            processedSounds[langText][dialectText] = {phonSystemText: [phonText]}
-            continue
-        if phonSystemText not in processedSounds[langText][dialectText]:
-            processedSounds[langText][dialectText][phonSystemText] = [phonText]
-            continue
-        processedSounds[langText][dialectText][phonSystemText].append(phonText)
+			if keyText not in tempExamples:
+				tempExamples[keyText] = {
+					"type": "example",
+					"text": [],
+					targetLang: translationText,
+				}
+			tempExamples[keyText]["text"].append(text)
+			if romanText:
+				tempExamples[keyText][romanSystemText] = romanText
 
-    return processedSounds
+		return list(tempExamples.values()) + skippedExamples
+
+	processedSenses = []
+	for sense in senseList:
+		if "examples" in sense:
+			processedSense = sense
+			processedSense["examples"] = processExamples(sense["examples"])
+			processedSenses.append(processedSense)
+
+		# Add other sense-related fix here later.
+
+	return processedSenses
+
+
+def processSoundList(soundList: list[dict[str, Any]]) -> dict[str, Any]:
+	# {"lang":{"dialect": {"system": ["phonatic"]}}}
+	# "_" = not found
+
+	# key 'tags' contains:
+	#   - language ["Mandarin"]
+	#   - phonetic writting system ["Pinyin", "bopomofo"]
+	#   - dialag of each langauge ["standard", "Chendu", "Xi'an"]
+	#
+	# Since the order is random, the groupping is assess only by
+	# Language and phonetic writting system for simplicity
+	# Otherwise the string will be interpreted as dialect/place name
+	# Note that many item in data["sounds"] are not extracted properly
+	# in the first place, so only correctly extracted one will be rendered
+
+	# might need to adding more languages in the future
+	# data from wiktextract does not provide the groupping
+	NORTHERN_MIN: tuple[str] = "Jian'ou"  # noqa:F841
+	EASTERN_MIN: tuple[str] = "Fuzhou"  # noqa:F841
+	SOUTHERN_MIN: tuple[str] = ("Hokkien", "Teochew", "Leizhou")  # noqa:F841
+
+	# it seem like readings without specified phonetic system have default
+	# however, i'm not so sure and the list here is based purely on
+	# wiktionary page of the character「我」
+	DEFAULT_PS = {
+		"Mandarin": "Pinyin",
+		"Cantonese": "Jyutping",
+		"Hakka": "Hakka Romanization System",
+	}
+
+	PREFERRED_PS_NAME = {
+		"Hanyu-Pinyin": "Pinyin",
+		"Latinxua-Sin-Wenz": "Scuanxua Ladinxua Xin Wenz",
+		"Gwoyeu-Romatsyh": "Gwoyeu Romatsyh",
+		"Kienning-Colloquial-Romanized": "Kienning Colloquial Romanized",
+		"Foochow-Romanized": "Bàng-uâ-cê",
+		"Tai-lo": "Tâi-lô",
+		"Phofsit-Daibuun": "Phofsit Daibuun",
+		"PFS": "Pha̍k-fa-sṳ",
+		"Hakka-Romanization-System": "Hakka Romanization System",
+		"Guangdong-Romanization": "Guangdong",
+		"Wiktionary-specific": "Wiktionary",
+		"Sinological-IPA": "IPA",
+		"bopomofo": "Bopomofo",
+	}
+
+	processedSounds = {}
+
+	for sound in soundList:
+		tags = sound.get("tags")
+		if not tags:
+			continue
+
+		lang = [t for t in tags if t in LANGS]
+		if not lang:
+			continue
+		langText = lang[0]
+
+		phonSystem = [t for t in tags if t in PHON_SYSTEMS]
+		if not phonSystem:
+			phonSystem.append(DEFAULT_PS.get(langText, ""))
+		phonSystemText = ", ".join(PREFERRED_PS_NAME.get(p, p) for p in phonSystem)
+		if not phonSystemText:
+			phonSystemText = "_"
+
+		dialect = [t for t in tags if t != langText and t not in phonSystem]
+		dialectText = ", ".join(dialect)
+		if not dialectText:
+			dialectText = "_"
+
+		# Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
+		# i.e., "uie\x06". This seem to be an error from wiktionary side.
+		phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
+		if not phonText or phonText == "uie\x06":
+			continue
+
+		if langText not in processedSounds:
+			processedSounds[langText] = {dialectText: {phonSystemText: [phonText]}}
+			continue
+		if dialectText not in processedSounds[langText]:
+			processedSounds[langText][dialectText] = {phonSystemText: [phonText]}
+			continue
+		if phonSystemText not in processedSounds[langText][dialectText]:
+			processedSounds[langText][dialectText][phonSystemText] = [phonText]
+			continue
+		processedSounds[langText][dialectText][phonSystemText].append(phonText)
+
+	return processedSounds
 
 
 def processChinese(data: dict[str, Any]) -> dict[str, Any]:
-    if "sounds" in data:
-        data["sounds"] = processSoundList(data["sounds"])
-    # TODO
-    return data
+	if "sounds" in data:
+		data["sounds"] = processSoundList(data["sounds"])
+	if "senses" in data:
+		data["senses"] = processSenses(data["senses"])
+	return data

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -72,7 +72,8 @@ def processSoundList(
         "Hakka-Romanization-System": "Hakka Romanization System",
         "Guangdong-Romanization": "Guangdong",
         "Wiktionary-specific": "Wiktionary",
-        "Sinological-IPA": "ipa"
+        "Sinological-IPA": "IPA",
+        "bopomofo": "Bopomofo"
     }
 
     processedSounds = {}

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -99,9 +99,9 @@ def processSoundList(
         if not dialectText:
             dialectText = "_"
 
-        phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
         # Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
         # i.e., "uie\x06". This seem to be an error from wiktionary side.
+        phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
         if not phonText or phonText == "uie\x06":
             continue
 

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -100,8 +100,10 @@ def processSoundList(
             dialectText = "_"
 
         phonText = sound.get("zh-pron", "") + sound.get("ipa", "")
-        if not phonText:
-            return None
+        # Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
+        # i.e., "uie\x06". This seem to be an error from wiktionary side.
+        if not phonText or phonText == "uie\x06":
+            continue
 
         if langText not in processedSounds:
             processedSounds[langText] = {dialectText: {phonSystemText: [phonText]}}


### PR DESCRIPTION
A fix to #637. I think this is the last problem I found. 

<img width="471" alt="image" src="https://github.com/user-attachments/assets/1efa3244-ee4d-44b0-b60e-79a726c3477c" />

See [下 in Wiktionary](https://en.wiktionary.org/wiki/%E4%B8%8B) for comparison.