### PR TITLE
Wiktextract: Use `""` instead of `"_"` for fallback key in `zh_utils.py/processSound`

### DIFF
--- a/pyglossary/plugins/wiktextract/reader.py
+++ b/pyglossary/plugins/wiktextract/reader.py
@@ -272,7 +272,7 @@ class Reader:
 		def writePhonDialect(hf: T_htmlfile, dialect: dict[str, Any]) -> None:
 			with hf.element("ul"):
 				for phonSystem, text in dialect.items():
-					className = f"pron {phonSystem}" if phonSystem != "_" else "pron"
+					className = f"pron {phonSystem}" if phonSystem else "pron"
 					with hf.element("li"):
 						with hf.element(
 							"font",
@@ -282,7 +282,7 @@ class Reader:
 							},
 						):
 							hf.write(str(", ".join(text)))
-						if phonSystem != "_":
+						if phonSystem:
 							hf.write(f" ({phonSystem})")
 
 		with hf.element("div", attrib={"class": "pronunciations"}):
@@ -290,7 +290,7 @@ class Reader:
 				with hf.element("ul"), hf.element("li"):
 					hf.write(f"{lang}: ")
 					for dialect in soundList[lang]:
-						if dialect == "_":
+						if not dialect:
 							writePhonDialect(hf, soundList[lang][dialect])
 							continue
 						with hf.element("ul"), hf.element("li"):

--- a/pyglossary/plugins/wiktextract/zh_utils.py
+++ b/pyglossary/plugins/wiktextract/zh_utils.py
@@ -140,7 +140,6 @@ def processSenses(senseList: dict[str, Any]) -> list[dict[str, Any]] | None:
 
 def processSoundList(soundList: list[dict[str, Any]]) -> dict[str, Any]:
 	# {"lang":{"dialect": {"system": ["phonatic"]}}}
-	# "_" = not found
 
 	# key 'tags' contains:
 	#   - language ["Mandarin"]
@@ -200,13 +199,9 @@ def processSoundList(soundList: list[dict[str, Any]]) -> dict[str, Any]:
 		if not phonSystem:
 			phonSystem.append(DEFAULT_PS.get(langText, ""))
 		phonSystemText = ", ".join(PREFERRED_PS_NAME.get(p, p) for p in phonSystem)
-		if not phonSystemText:
-			phonSystemText = "_"
 
 		dialect = [t for t in tags if t != langText and t not in phonSystem]
 		dialectText = ", ".join(dialect)
-		if not dialectText:
-			dialectText = "_"
 
 		# Few entries from wiktionary e.g.,「鿦」　have non-unicode text string
 		# i.e., "uie\x06". This seem to be an error from wiktionary side.


### PR DESCRIPTION
An improvement to #640 as discussed in #637.