### PR TITLE
Add Yomichan dictionaries reader

### DIFF
--- a/doc/p/__index__.md
+++ b/doc/p/__index__.md
@@ -3,7 +3,6 @@
 | Aard 2 (.slob) | Aard2Slob | [aard2_slob.md](./aard2_slob.md) |
 | Almaany.com (SQLite3) | Almaany | [almaany.md](./almaany.md) |
 | AppleDict Source | AppleDict | [appledict.md](./appledict.md) |
-| AppleDict Binary | AppleDictBin | [appledict_bin.md](./appledict_bin.md) |
 | AyanDict SQLite | AyanDictSQLite | [ayandict_sqlite.md](./ayandict_sqlite.md) |
 | Babylon (.BGL) | BabylonBgl | [babylon_bgl.md](./babylon_bgl.md) |
 | cc-kedict | cc-kedict | [cc_kedict.md](./cc_kedict.md) |
@@ -22,7 +21,6 @@
 | Kobo E-Reader Dictionary | Kobo | [kobo.md](./kobo.md) |
 | Kobo E-Reader Dictfile (.df) | Dictfile | [kobo_dictfile.md](./kobo_dictfile.md) |
 | Mobipocket (.mobi) E-Book | Mobi | [mobi.md](./mobi.md) |
-| EDICT2 (CEDICT) (.u8) | EDICT2 | [edict2.md](./edict2.md) |
 | EDLIN | Edlin | [edlin.md](./edlin.md) |
 | FreeDict (.tei) | FreeDict | [freedict.md](./freedict.md) |
 | Gettext Source (.po) | GettextPo | [gettext_po.md](./gettext_po.md) |
@@ -43,8 +41,6 @@
 | Wiktextract (.jsonl) | Wiktextract | [wiktextract.md](./wiktextract.md) |
 | WordNet | Wordnet | [wordnet.md](./wordnet.md) |
 | Wordset.org JSON directory | Wordset | [wordset.md](./wordset.md) |
-| XDXF (.xdxf) | Xdxf | [xdxf.md](./xdxf.md) |
-| XDXF with CSS and JS | XdxfCss | [xdxf_css.md](./xdxf_css.md) |
 | XDXF Lax (.xdxf) | XdxfLax | [xdxf_lax.md](./xdxf_lax.md) |
 | Yomichan (.zip) | Yomichan | [yomichan.md](./yomichan.md) |
 | Zim (.zim, for Kiwix) | Zim | [zim.md](./zim.md) |

--- a/doc/p/__index__.md
+++ b/doc/p/__index__.md
@@ -3,6 +3,7 @@
 | Aard 2 (.slob) | Aard2Slob | [aard2_slob.md](./aard2_slob.md) |
 | Almaany.com (SQLite3) | Almaany | [almaany.md](./almaany.md) |
 | AppleDict Source | AppleDict | [appledict.md](./appledict.md) |
+| AppleDict Binary | AppleDictBin | [appledict_bin.md](./appledict_bin.md) |
 | AyanDict SQLite | AyanDictSQLite | [ayandict_sqlite.md](./ayandict_sqlite.md) |
 | Babylon (.BGL) | BabylonBgl | [babylon_bgl.md](./babylon_bgl.md) |
 | cc-kedict | cc-kedict | [cc_kedict.md](./cc_kedict.md) |
@@ -21,6 +22,7 @@
 | Kobo E-Reader Dictionary | Kobo | [kobo.md](./kobo.md) |
 | Kobo E-Reader Dictfile (.df) | Dictfile | [kobo_dictfile.md](./kobo_dictfile.md) |
 | Mobipocket (.mobi) E-Book | Mobi | [mobi.md](./mobi.md) |
+| EDICT2 (CEDICT) (.u8) | EDICT2 | [edict2.md](./edict2.md) |
 | EDLIN | Edlin | [edlin.md](./edlin.md) |
 | FreeDict (.tei) | FreeDict | [freedict.md](./freedict.md) |
 | Gettext Source (.po) | GettextPo | [gettext_po.md](./gettext_po.md) |
@@ -41,6 +43,8 @@
 | Wiktextract (.jsonl) | Wiktextract | [wiktextract.md](./wiktextract.md) |
 | WordNet | Wordnet | [wordnet.md](./wordnet.md) |
 | Wordset.org JSON directory | Wordset | [wordset.md](./wordset.md) |
+| XDXF (.xdxf) | Xdxf | [xdxf.md](./xdxf.md) |
+| XDXF with CSS and JS | XdxfCss | [xdxf_css.md](./xdxf_css.md) |
 | XDXF Lax (.xdxf) | XdxfLax | [xdxf_lax.md](./xdxf_lax.md) |
 | Yomichan (.zip) | Yomichan | [yomichan.md](./yomichan.md) |
 | Zim (.zim, for Kiwix) | Zim | [zim.md](./zim.md) |

--- a/doc/p/yomichan.md
+++ b/doc/p/yomichan.md
@@ -8,7 +8,7 @@
 | snake_case_name | yomichan                                              |
 | Description     | Yomichan (.zip)                                       |
 | Extensions      | `.zip`                                                |
-| Read support    | No                                                    |
+| Read support    | Yes                                                   |
 | Write support   | Yes                                                   |
 | Single-file     | Yes                                                   |
 | Kind            | 📦 package                                             |

--- a/plugins-meta/index.json
+++ b/plugins-meta/index.json
@@ -2045,7 +2045,7 @@
 		"canWrite": true,
 		"sortOnWrite": "always",
 		"sortKeyName": "headword",
-		"readCompressions": ["zip"],
+		"readOptions": {},
 		"writeOptions": {
 			"term_bank_size": 10000,
 			"term_from_headword_only": true,
@@ -2062,7 +2062,10 @@
 		},
 		"writeDepends": {
 			"bs4": "beautifulsoup4"
-		}
+		},
+		"readCompressions": [
+			"zip"
+		]
 	},
 	{
 		"module": "zimfile",

--- a/plugins-meta/index.json
+++ b/plugins-meta/index.json
@@ -2041,10 +2041,11 @@
 				"comment": "When given, if any substring of an entry's definition matches this regular expression, then the term(s) created from entry are labeled as i-adjective. Yomichan uses this information to match conjugated forms of words. `^` and `$` can be used to match start and end of lines, respectively. For example, setting this option to `r'^\\(\u5f62\\)$'` identify entries where there's a line of '(\u5f62)'."
 			}
 		},
-		"canRead": false,
+		"canRead": true,
 		"canWrite": true,
 		"sortOnWrite": "always",
 		"sortKeyName": "headword",
+		"readCompressions": ["zip"],
 		"writeOptions": {
 			"term_bank_size": 10000,
 			"term_from_headword_only": true,

--- a/pyglossary/plugin_handler.py
+++ b/pyglossary/plugin_handler.py
@@ -318,7 +318,7 @@ class PluginHandler:
 		skipDisabledPlugins: bool = True,
 	) -> None:
 		"""
-		Initialize the glossary class (not an insatnce).
+		Initialize the glossary class (not an instance).
 		Must be called only once, so make sure you put it in the right place.
 		Probably in the top of your program's main function or module.
 		"""

--- a/pyglossary/plugins/yomichan/__init__.py
+++ b/pyglossary/plugins/yomichan/__init__.py
@@ -9,9 +9,11 @@ from pyglossary.option import (
 	StrOption,
 )
 
+from .reader import Reader
 from .writer import Writer
 
 __all__ = [
+	"Reader",
 	"Writer",
 	"description",
 	"enable",

--- a/pyglossary/plugins/yomichan/reader.py
+++ b/pyglossary/plugins/yomichan/reader.py
@@ -2,23 +2,24 @@
 from __future__ import annotations
 
 import re
+from operator import itemgetter
 from typing import (
-    TYPE_CHECKING,
+	TYPE_CHECKING,
 )
 from zipfile import ZipFile, ZipInfo
 
 from pyglossary.json_utils import jsonToData
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator
+	from collections.abc import Generator, Iterator
 
-    from pyglossary.glossary_types import EntryType, ReaderGlossaryType
+	from pyglossary.glossary_types import EntryType, ReaderGlossaryType
 
-    from .types import (
-        DefinitionObj,
-        StructuredContent,
-        YomichanDefinition,
-    )
+	from .types import (
+		DefinitionObj,
+		StructuredContent,
+		YomichanDefinition,
+	)
 
 __all__ = ["Reader"]
 
@@ -28,162 +29,160 @@ BASE_BANK_PATTERN = re.compile(r".+_(meta_)?bank_(\d+).json\Z")
 
 
 class Reader:
-    useByteProgress = False
-    compressions = ["zip"]
+	useByteProgress = False
+	compressions = ["zip"]
 
-    def __init__(self, glos: ReaderGlossaryType) -> None:
-        self._glos = glos
-        self.clear()
+	def __init__(self, glos: ReaderGlossaryType) -> None:
+		self._glos = glos
+		self.clear()
 
-    def clear(self) -> None:
-        self._dictFile: ZipFile | None = None
-        self._filename = ""
-        self._isSequenced = False
-        self._termBankFiles = []
-        self._resourceFiles = []
+	def clear(self) -> None:
+		self._dictFile: ZipFile | None = None
+		self._filename = ""
+		self._isSequenced = False
+		self._termBankFiles = []
+		self._resourceFiles = []
 
-    def open(self, filename: str) -> None:
-        # TODO: Sanitize name
-        self._filename = filename
-        self._dictFile = ZipFile(filename)
-        resourceFiles = []
-        termFiles: list[tuple[int, ZipInfo]] = []
-        for file in self._dictFile.filelist:
-            match = TERM_BASE_PATTERN.match(file.filename)
-            if match is not None:
-                termFiles.append((int(match.group(1)), file))
-                continue
-            if file.filename == "index.json" or file.is_dir():
-                continue
-            # As currently there is no support for them
-            if BASE_BANK_PATTERN.match(file.filename):
-                continue
-            resourceFiles.append(file)
-        self._termBankFiles = [val for _, val in sorted(termFiles, key=lambda v: v[0])]
-        self._resourceFiles = resourceFiles
-        self._ReadIndex()
+	def open(self, filename: str) -> None:
+		# TODO: Sanitize name
+		self._filename = filename
+		self._dictFile = ZipFile(filename)
+		resourceFiles = []
+		termFiles: list[tuple[int, ZipInfo]] = []
+		for file in self._dictFile.filelist:
+			match = TERM_BASE_PATTERN.match(file.filename)
+			if match is not None:
+				termFiles.append((int(match.group(1)), file))
+				continue
+			if file.filename == "index.json" or file.is_dir():
+				continue
+			# As currently there is no support for them
+			if BASE_BANK_PATTERN.match(file.filename):
+				continue
+			resourceFiles.append(file)
+		self._termBankFiles = [val for _, val in sorted(termFiles, key=itemgetter(0))]
+		self._resourceFiles = resourceFiles
+		self._ReadIndex()
 
-    def close(self) -> None:
-        if self._dictFile:
-            self._dictFile.close()
-        self.clear()
+	def close(self) -> None:
+		if self._dictFile:
+			self._dictFile.close()
+		self.clear()
 
-    def __len__(self) -> int:
-        if self._dictFile is None:
-            raise RuntimeError("Yomichan: len(reader) called while reader is not open")
-        # TODO: how do I count real length??
-        return len(self._termBankFiles)
+	def __len__(self) -> int:
+		if self._dictFile is None:
+			raise RuntimeError("Yomichan: len(reader) called while reader is not open")
+		# TODO: how do I count real length??
+		return len(self._termBankFiles)
 
-    def __iter__(self) -> Iterator[EntryType]:
-        if self._dictFile is None:
-            raise RuntimeError("Yomichan: resources were read while reader is not open")
-        for termBankFile in self._termBankFiles:
-            yield from self._ReadTermBank(termBankFile.filename)
-        yield from self._ReadUsedResources()
+	def __iter__(self) -> Iterator[EntryType]:
+		if self._dictFile is None:
+			raise RuntimeError("Yomichan: resources were read while reader is not open")
+		for termBankFile in self._termBankFiles:
+			yield from self._ReadTermBank(termBankFile.filename)
+		yield from self._ReadUsedResources()
 
+	def _ReadIndex(self) -> None:
+		if self._dictFile is None:
+			raise RuntimeError("Yomichan: resources were read while reader is not open")
+		with self._dictFile.open("index.json") as indexFile:
+			index = jsonToData(indexFile.read())
+		if not isinstance(index, dict):
+			raise RuntimeError("Yomichan: ill-formed yomichan dictionary")
+		if index["format"] != 3:
+			raise NotImplementedError(
+				"Yomichan: supported only dictionaries of 3 version",
+			)
+		self._glos.setInfo("sourceLang", "ja")
+		for c_field in FIELDS_TO_WRITE:
+			value = index.get(c_field)
+			if value is not None:
+				self._glos.setInfo(c_field, value)
+		self._isSequenced = index.get("isSequenced", False)
 
-    def _ReadIndex(self) -> None:
-        if self._dictFile is None:
-            raise RuntimeError("Yomichan: resources were read while reader is not open")
-        with self._dictFile.open("index.json") as indexFile:
-            index = jsonToData(indexFile.read())
-        if not isinstance(index, dict):
-            raise RuntimeError("Yomichan: ill-formed yomichan dictionary")
-        if index["format"] != 3:
-            raise NotImplementedError(
-                "Yomichan: supported only dictionaries of 3 version",
-            )
-        self._glos.setInfo("sourceLang", "ja")
-        for c_field in FIELDS_TO_WRITE:
-            value = index.get(c_field)
-            if value is not None:
-                self._glos.setInfo(c_field, value)
-        self._isSequenced = index.get("isSequenced", False)
+	def _ReadTermBank(self, termBankName: str) -> Generator[EntryType, None, None]:
+		if self._dictFile is None:
+			raise RuntimeError("Yomichan: resources were read while reader is not open")
+		with self._dictFile.open(termBankName) as termBankFile:
+			termBank = jsonToData(termBankFile.read())
+		for term in termBank:
+			word = term[0]
+			if reading := term[1]:
+				word = [word, reading]
+			definition = _ReadDefinition(term[5])
+			yield self._glos.newEntry(word, definition, defiFormat="h")
 
-    def _ReadTermBank(self, termBankName: str) -> Generator[EntryType, None, None]:
-        if self._dictFile is None:
-            raise RuntimeError("Yomichan: resources were read while reader is not open")
-        with self._dictFile.open(termBankName) as termBankFile:
-            termBank = jsonToData(termBankFile.read())
-        for term in termBank:
-            word = term[0]
-            if (reading := term[1]):
-                word = [word, reading]
-            definition = _ReadDefinition(term[5])
-            yield self._glos.newEntry(word, definition, defiFormat="h")
-
-    def _ReadUsedResources(self) -> Generator[EntryType, None, None]:
-        if self._dictFile is None:
-            raise RuntimeError("Yomichan: resources were read while reader is not open")
-        for file in self._resourceFiles:
-            with self._dictFile.open(file.filename) as rawFile:
-                data = rawFile.read()
-            yield self._glos.newDataEntry(file.filename, data)
+	def _ReadUsedResources(self) -> Generator[EntryType, None, None]:
+		if self._dictFile is None:
+			raise RuntimeError("Yomichan: resources were read while reader is not open")
+		for file in self._resourceFiles:
+			with self._dictFile.open(file.filename) as rawFile:
+				data = rawFile.read()
+			yield self._glos.newDataEntry(file.filename, data)
 
 
 def _ReadSubStructuredContent(elem: StructuredContent) -> str:
-    if isinstance(elem, str):
-        return elem
-    if isinstance(elem, list):
-        return " ".join(map(_ReadSubStructuredContent, elem))
-    styles = []
-    additional_properties = [
-        f' {key}="{val}"'
-        for key, val in elem.get("data", {}).items()
-    ]
-    if "style" in elem:
-        styles = [f"{k}: {v};" for k, v in elem["style"].items()]
-    for field in ("lang", "title", "alt", "href", "colSpan", "rowSpan"):
-        if field not in elem:
-            continue
-        additional_properties.append(f' {field}="{elem.get(field)}"')
+	if isinstance(elem, str):
+		return elem
+	if isinstance(elem, list):
+		return " ".join(map(_ReadSubStructuredContent, elem))
+	styles = []
+	additional_properties = [
+		f' {key}="{val}"' for key, val in elem.get("data", {}).items()
+	]
+	if "style" in elem:
+		styles = [f"{k}: {v};" for k, v in elem["style"].items()]
+	for field in ("lang", "title", "alt", "href", "colSpan", "rowSpan"):
+		if field not in elem:
+			continue
+		additional_properties.append(f' {field}="{elem.get(field)}"')
 
-    # Tag processing
-    # TODO: Process all tags?
-    if elem["tag"] == "br":
-        return f"<br{''.join(additional_properties)}>"
-    if elem["tag"] == "img":
-        for name in ("width", "height"):
-            if name not in elem:
-                continue
-            if elem.get("sizeUnits", "px") == "em":
-                styles.append(f"{name}: {elem.get(name)}em;")
-            else:
-                additional_properties.append(f" {name}={elem.get(name)}")
-        if "verticalAlign" in elem:
-            styles.append(f"vertical-align: {elem['verticalAlign']};")
-        additional_properties.append(f' style="{"".join(styles)}"')
-        additional_properties = "".join(additional_properties)
-        return f"<img src=\"{elem['path']}\"{additional_properties}>"
-    # General tags
-    tag = elem["tag"]
-    content = _ReadSubStructuredContent(elem.get("content", ""))
-    additional_properties.append(f' style="{"".join(styles)}"')
-    additional_properties = "".join(additional_properties)
-    return f"<{tag}{additional_properties}>{content}</{tag}>"
+	# Tag processing
+	# TODO: Process all tags?
+	if elem["tag"] == "br":
+		return f"<br{''.join(additional_properties)}>"
+	if elem["tag"] == "img":
+		for name in ("width", "height"):
+			if name not in elem:
+				continue
+			if elem.get("sizeUnits", "px") == "em":
+				styles.append(f"{name}: {elem.get(name)}em;")
+			else:
+				additional_properties.append(f" {name}={elem.get(name)}")
+		if "verticalAlign" in elem:
+			styles.append(f"vertical-align: {elem['verticalAlign']};")
+		additional_properties.append(f' style="{"".join(styles)}"')
+		additional_properties = "".join(additional_properties)
+		return f'<img src="{elem["path"]}"{additional_properties}>'
+	# General tags
+	tag = elem["tag"]
+	content = _ReadSubStructuredContent(elem.get("content", ""))
+	additional_properties.append(f' style="{"".join(styles)}"')
+	additional_properties = "".join(additional_properties)
+	return f"<{tag}{additional_properties}>{content}</{tag}>"
 
 
 def _ReadStructuredContent(elem: DefinitionObj) -> str:
-    if elem["type"] == "text":
-        return elem["text"]
-    if elem["type"] == "structured-content":
-        return _ReadSubStructuredContent(elem["content"])
-    if elem["type"] == "image":
-        properties = []
-        for name in ["alt", "width", "height", "title"]:
-            prop = elem.get(name)
-            if prop is not None:
-                properties.append(f' {name}="{prop}"')
-        return f"<img src=\"{elem['path']}\"{''.join(properties)}>"
-    raise RuntimeError("Ill-formed Yomichan dictionary")
+	if elem["type"] == "text":
+		return elem["text"]
+	if elem["type"] == "structured-content":
+		return _ReadSubStructuredContent(elem["content"])
+	if elem["type"] == "image":
+		properties = []
+		for name in ["alt", "width", "height", "title"]:
+			prop = elem.get(name)
+			if prop is not None:
+				properties.append(f' {name}="{prop}"')
+		return f'<img src="{elem["path"]}"{"".join(properties)}>'
+	raise RuntimeError("Ill-formed Yomichan dictionary")
 
 
 def _ReadDefinition(definition: list[YomichanDefinition]) -> str:
-    def _ParseDefinition(defi: YomichanDefinition) -> str:
-        if isinstance(defi, str):
-            return defi
-        if isinstance(defi, dict):
-            return _ReadStructuredContent(defi)
-        raise NotImplementedError("Yomichan: unknown elem in definition: {defi}")
+	def _ParseDefinition(defi: YomichanDefinition) -> str:
+		if isinstance(defi, str):
+			return defi
+		if isinstance(defi, dict):
+			return _ReadStructuredContent(defi)
+		raise NotImplementedError(f"Yomichan: unknown elem in definition: {defi}")
 
-    return "\n".join(map(_ParseDefinition, definition))
+	return "\n".join(map(_ParseDefinition, definition))

--- a/pyglossary/plugins/yomichan/reader.py
+++ b/pyglossary/plugins/yomichan/reader.py
@@ -4,19 +4,21 @@ from __future__ import annotations
 import re
 from typing import (
     TYPE_CHECKING,
-    TypedDict,
 )
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
 
 from pyglossary.json_utils import jsonToData
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
-    from typing import Literal, TypeAlias
-
-    from typing_extensions import Required
 
     from pyglossary.glossary_types import EntryType, ReaderGlossaryType
+
+    from .types import (
+        DefinitionObj,
+        StructuredContent,
+        YomichanDefinition,
+    )
 
 __all__ = ["Reader"]
 
@@ -36,19 +38,24 @@ class Reader:
         self._dictFile: ZipFile | None = None
         self._filename = ""
         self._isSequenced = False
-        self._termFiles = []
+        self._termBankFiles = []
+        self._resourceFiles = []
 
     def open(self, filename: str) -> None:
         # TODO: Sanitize name
         self._filename = filename
         self._dictFile = ZipFile(filename)
-        termFiles: list[tuple[int, str]] = []
+        resourceFiles = []
+        termFiles: list[tuple[int, ZipInfo]] = []
         for file in self._dictFile.filelist:
             match = TERM_BASE_PATTERN.match(file.filename)
-            if match is None:
+            if match is not None:
+                termFiles.append((int(match.group(1)), file))
+            if file.filename == "index.json" or file.is_dir():
                 continue
-            termFiles.append((int(match.group(1)), file.filename))
-        self._termFiles = [val for _, val in sorted(termFiles, key=lambda v: v[0])]
+            resourceFiles.append(file)
+        self._termBankFiles = [val for _, val in sorted(termFiles, key=lambda v: v[0])]
+        self._resourceFiles = resourceFiles
         self._ReadIndex()
 
     def close(self) -> None:
@@ -57,22 +64,29 @@ class Reader:
         self.clear()
 
     def __len__(self) -> int:
-        # TODO: LEN
-        return 0
-
+        if self._dictFile is None:
+            raise RuntimeError("Yomichan: len(reader) called while reader is not open")
+        # TODO: how do I count real length??
+        return len(self._termBankFiles)
 
     def __iter__(self) -> Iterator[EntryType]:
-        for termFile in self._termFiles:
-            yield from self._ReadTermBank(termFile)
+        if self._dictFile is None:
+            raise RuntimeError("Yomichan: resources were read while reader is not open")
+        for termBankFile in self._termBankFiles:
+            yield from self._ReadTermBank(termBankFile.filename)
         yield from self._ReadUsedResources()
 
 
     def _ReadIndex(self) -> None:
+        if self._dictFile is None:
+            raise RuntimeError("Yomichan: resources were read while reader is not open")
         with self._dictFile.open("index.json") as indexFile:
             index = jsonToData(indexFile.read())
         assert isinstance(index, dict), "Invalid format"
         if index["format"] != 3:
-            raise NotImplementedError("Supported only dictionaries of 3 version")
+            raise NotImplementedError(
+                "Yomichan: Supported only dictionaries of 3 version",
+            )
         self._glos.setInfo("sourceLang", "ja")
         for c_field in FIELDS_TO_WRITE:
             value = index.get(c_field)
@@ -81,6 +95,8 @@ class Reader:
         self._isSequenced = index.get("isSequenced", False)
 
     def _ReadTermBank(self, termBankName: str) -> Generator[EntryType, None, None]:
+        if self._dictFile is None:
+            raise RuntimeError("Yomichan: resources were read while reader is not open")
         with self._dictFile.open(termBankName) as termBankFile:
             termBank = jsonToData(termBankFile.read())
         for term in termBank:
@@ -91,55 +107,15 @@ class Reader:
             yield self._glos.newEntry(word, definition, defiFormat="h")
 
     def _ReadUsedResources(self) -> Generator[EntryType, None, None]:
-        for file in self._dictFile.filelist:
-            if file.is_dir() or \
-                file.filename in self._termFiles or \
-                file.filename == "index.json":
-                continue
+        if self._dictFile is None:
+            raise RuntimeError("Yomichan: resources were read while reader is not open")
+        for file in self._resourceFiles:
             with self._dictFile.open(file.filename) as rawFile:
                 data = rawFile.read()
             yield self._glos.newDataEntry(file.filename, data)
 
 
-class StructuredContent(TypedDict, total=False):
-    type: Required[Literal["text", "structured-content", "img"]]
-    # Text
-    text: str
-    # Structured Content
-    content: StructuredContentChild
-    # Image
-    path: str
-    width: int
-    height: int
-    title: str
-    alt: str
-    description: str
-    pixelated: bool
-    imageRendering: Literal["auto", "pixelated", "crisp=edges"]
-    appearance: Literal["auto", "monochrome"]
-    background: bool
-    collapsed: bool
-    collapsible: bool
-
-
-class StructuredContentChildObj(TypedDict, total=False):
-    tag: Required[Literal["br", "div", "img", "a"]]
-    content: "StructuredContentChildObj"
-    data: dict[str, str]
-    # Local image file
-    path: str
-    # Only for links will be match for r"^(?:https?:|\?)[\w\W]*"
-    #   Internal links start from ?
-    href: str
-    lang: str
-
-
-if TYPE_CHECKING:
-    StructuredContentChild: TypeAlias = str | list["StructuredContentChild"] | "StructuredContentChildObj"
-    YomichanDefinitionType = str | StructuredContent | list
-
-
-def _ReadSubStructuredContent(elem: StructuredContentChild) -> str:
+def _ReadSubStructuredContent(elem: StructuredContent) -> str:
     if isinstance(elem, str):
         return elem
     if isinstance(elem, list):
@@ -162,19 +138,18 @@ def _ReadSubStructuredContent(elem: StructuredContentChild) -> str:
     return tag
 
 
-def _ReadStructuredContent(elem: StructuredContent) -> str:
-    elem_type = elem["type"]
-    if elem_type == "text":
+def _ReadStructuredContent(elem: DefinitionObj) -> str:
+    if elem["type"] == "text":
         return elem["text"]
-    if elem_type == "structured-content":
+    if elem["type"] == "structured-content":
         return _ReadSubStructuredContent(elem["content"])
-    if elem_type == "img":
-        return f"<img src=\"{elem['href']}\">"
+    if elem["type"] == "image":
+        return f"<img src=\"{elem['path']}\">"
     raise RuntimeError("Ill-formed Yomichan dictionary")
 
 
-def _ReadDefinition(definition: list[YomichanDefinitionType]) -> str:
-    def _ParseDefinition(defi: YomichanDefinitionType) -> str:
+def _ReadDefinition(definition: list[YomichanDefinition]) -> str:
+    def _ParseDefinition(defi: YomichanDefinition) -> str:
         if isinstance(defi, str):
             return defi
         if isinstance(defi, dict):
@@ -182,10 +157,3 @@ def _ReadDefinition(definition: list[YomichanDefinitionType]) -> str:
         raise NotImplementedError("Unknown elem in definition: {defi}")
 
     return "\n".join(map(_ParseDefinition, definition))
-
-
-# + Read zip file
-# - Read metadata from index.json
-# - Read definitions from term base
-# - transfer other data required by terms
-

--- a/pyglossary/plugins/yomichan/reader.py
+++ b/pyglossary/plugins/yomichan/reader.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import re
+from typing import (
+    TYPE_CHECKING,
+    TypedDict,
+)
+from zipfile import ZipFile
+
+from pyglossary.json_utils import jsonToData
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+    from typing import Literal, TypeAlias
+
+    from typing_extensions import Required
+
+    from pyglossary.glossary_types import EntryType, ReaderGlossaryType
+
+__all__ = ["Reader"]
+
+FIELDS_TO_WRITE = ["title", "author", "description", "sourceLanguage", "targetLanguage"]
+TERM_BASE_PATTERN = re.compile(r"term_bank_(\d+).json\Z")
+
+
+class Reader:
+    useByteProgress = False
+    compressions = ["zip"]
+
+    def __init__(self, glos: ReaderGlossaryType) -> None:
+        self._glos = glos
+        self.clear()
+
+    def clear(self) -> None:
+        self._dictFile: ZipFile | None = None
+        self._filename = ""
+        self._isSequenced = False
+        self._termFiles = []
+
+    def open(self, filename: str) -> None:
+        # TODO: Sanitize name
+        self._filename = filename
+        self._dictFile = ZipFile(filename)
+        termFiles: list[tuple[int, str]] = []
+        for file in self._dictFile.filelist:
+            match = TERM_BASE_PATTERN.match(file.filename)
+            if match is None:
+                continue
+            termFiles.append((int(match.group(1)), file.filename))
+        self._termFiles = [val for _, val in sorted(termFiles, key=lambda v: v[0])]
+        self._ReadIndex()
+
+    def close(self) -> None:
+        if self._dictFile:
+            self._dictFile.close()
+        self.clear()
+
+    def __len__(self) -> int:
+        # TODO: LEN
+        return 0
+
+
+    def __iter__(self) -> Iterator[EntryType]:
+        for termFile in self._termFiles:
+            yield from self._ReadTermBank(termFile)
+        yield from self._ReadUsedResources()
+
+
+    def _ReadIndex(self) -> None:
+        with self._dictFile.open("index.json") as indexFile:
+            index = jsonToData(indexFile.read())
+        assert isinstance(index, dict), "Invalid format"
+        if index["format"] != 3:
+            raise NotImplementedError("Supported only dictionaries of 3 version")
+        self._glos.setInfo("sourceLang", "ja")
+        for c_field in FIELDS_TO_WRITE:
+            value = index.get(c_field)
+            if value is not None:
+                self._glos.setInfo(c_field, value)
+        self._isSequenced = index.get("isSequenced", False)
+
+    def _ReadTermBank(self, termBankName: str) -> Generator[EntryType, None, None]:
+        with self._dictFile.open(termBankName) as termBankFile:
+            termBank = jsonToData(termBankFile.read())
+        for term in termBank:
+            word = term[0]
+            if (reading := term[1]):
+                word = [word, reading]
+            definition = _ReadDefinition(term[5])
+            yield self._glos.newEntry(word, definition, defiFormat="h")
+
+    def _ReadUsedResources(self) -> Generator[EntryType, None, None]:
+        for file in self._dictFile.filelist:
+            if file.is_dir() or \
+                file.filename in self._termFiles or \
+                file.filename == "index.json":
+                continue
+            with self._dictFile.open(file.filename) as rawFile:
+                data = rawFile.read()
+            yield self._glos.newDataEntry(file.filename, data)
+
+
+class StructuredContent(TypedDict, total=False):
+    type: Required[Literal["text", "structured-content", "img"]]
+    # Text
+    text: str
+    # Structured Content
+    content: StructuredContentChild
+    # Image
+    path: str
+    width: int
+    height: int
+    title: str
+    alt: str
+    description: str
+    pixelated: bool
+    imageRendering: Literal["auto", "pixelated", "crisp=edges"]
+    appearance: Literal["auto", "monochrome"]
+    background: bool
+    collapsed: bool
+    collapsible: bool
+
+
+class StructuredContentChildObj(TypedDict, total=False):
+    tag: Required[Literal["br", "div", "img", "a"]]
+    content: "StructuredContentChildObj"
+    data: dict[str, str]
+    # Local image file
+    path: str
+    # Only for links will be match for r"^(?:https?:|\?)[\w\W]*"
+    #   Internal links start from ?
+    href: str
+    lang: str
+
+
+if TYPE_CHECKING:
+    StructuredContentChild: TypeAlias = str | list["StructuredContentChild"] | "StructuredContentChildObj"
+    YomichanDefinitionType = str | StructuredContent | list
+
+
+def _ReadSubStructuredContent(elem: StructuredContentChild) -> str:
+    if isinstance(elem, str):
+        return elem
+    if isinstance(elem, list):
+        return " ".join(map(_ReadSubStructuredContent, elem))
+    additional_properties = "".join((
+        f' {key}="{val}"'
+        for key, val in elem.get("data", {}).items()
+    ))
+    # TODO: Process all tags?
+    if elem["tag"] == "a":
+        additional_properties += f' href="{elem["href"]}"'
+    if elem["tag"] == "img":
+        tag = f"<img src=\"{elem['path']}\"{additional_properties}>"
+    elif elem["tag"] == "br":
+        tag = f"<br{additional_properties}>"
+    else:
+        tag = elem["tag"]
+        content = _ReadSubStructuredContent(elem.get("content", ""))
+        tag = f"<{tag}{additional_properties}>{content}</{tag}>"
+    return tag
+
+
+def _ReadStructuredContent(elem: StructuredContent) -> str:
+    elem_type = elem["type"]
+    if elem_type == "text":
+        return elem["text"]
+    if elem_type == "structured-content":
+        return _ReadSubStructuredContent(elem["content"])
+    if elem_type == "img":
+        return f"<img src=\"{elem['href']}\">"
+    raise RuntimeError("Ill-formed Yomichan dictionary")
+
+
+def _ReadDefinition(definition: list[YomichanDefinitionType]) -> str:
+    def _ParseDefinition(defi: YomichanDefinitionType) -> str:
+        if isinstance(defi, str):
+            return defi
+        if isinstance(defi, dict):
+            return _ReadStructuredContent(defi)
+        raise NotImplementedError("Unknown elem in definition: {defi}")
+
+    return "\n".join(map(_ParseDefinition, definition))
+
+
+# + Read zip file
+# - Read metadata from index.json
+# - Read definitions from term base
+# - transfer other data required by terms
+

--- a/pyglossary/plugins/yomichan/types.py
+++ b/pyglossary/plugins/yomichan/types.py
@@ -50,7 +50,7 @@ StructuredContentObj: TypeAlias = Union[
     "LinkTagStructContent",
 ]
 DataAttributes: TypeAlias = dict[str, str]
-StyleAttributes: TypeAlias = dict[str, str]
+StyleAttributes: TypeAlias = dict[str, str | int]
 
 class EmptyTagStructContent(TypedDict):
     tag: Literal["br"]

--- a/pyglossary/plugins/yomichan/types.py
+++ b/pyglossary/plugins/yomichan/types.py
@@ -6,105 +6,117 @@ from typing import Literal, TypeAlias, Union
 from typing_extensions import NotRequired, Required, TypedDict
 
 DefinitionObj: TypeAlias = Union[
-    "DefinitionString",
-    "DefinitionImage",
-    "DefinitionStructContent",
+	"DefinitionString",
+	"DefinitionImage",
+	"DefinitionStructContent",
 ]
 YomichanDefinition: TypeAlias = str | DefinitionObj | tuple[str, list[str]]
 
+
 class DefinitionString(TypedDict):
-    type: Literal["text"]
-    text: str
+	type: Literal["text"]
+	text: str
+
 
 class DefinitionImage(TypedDict, total=False):
-    type: Required[Literal["image"]]
-    path: Required[str]
-    width: int
-    height: int
-    title: str
-    alt: str
-    description: str
-    pixelated: bool
-    imageRendering: Literal["auto", "pixelated", "crisp=edges"]
-    appearance: Literal["auto", "monochrome"]
-    background: bool
-    collapsed: bool
-    collapsible: bool
+	type: Required[Literal["image"]]
+	path: Required[str]
+	width: int
+	height: int
+	title: str
+	alt: str
+	description: str
+	pixelated: bool
+	imageRendering: Literal["auto", "pixelated", "crisp=edges"]
+	appearance: Literal["auto", "monochrome"]
+	background: bool
+	collapsed: bool
+	collapsible: bool
+
 
 class DefinitionStructContent(TypedDict):
-    type: Literal["structured-content"]
-    content: StructuredContent
+	type: Literal["structured-content"]
+	content: StructuredContent
+
 
 StructuredContent: TypeAlias = Union[
-    str,
-    list["StructuredContent"],
-    "StructuredContentObj",
+	str,
+	list["StructuredContent"],
+	"StructuredContentObj",
 ]
 
 StructuredContentObj: TypeAlias = Union[
-    "EmptyTagStructContent",
-    "GenericContainerStructContent",
-    "TableStructContent",
-    "StylishContainerStructContent",
-    "ImageTagStructContent",
-    "LinkTagStructContent",
+	"EmptyTagStructContent",
+	"GenericContainerStructContent",
+	"TableStructContent",
+	"StylishContainerStructContent",
+	"ImageTagStructContent",
+	"LinkTagStructContent",
 ]
 DataAttributes: TypeAlias = dict[str, str]
 StyleAttributes: TypeAlias = dict[str, str | int]
 
+
 class EmptyTagStructContent(TypedDict):
-    tag: Literal["br"]
-    data: NotRequired[DataAttributes]
+	tag: Literal["br"]
+	data: NotRequired[DataAttributes]
+
 
 class GenericContainerStructContent(TypedDict, total=False):
-    tag: Required[Literal["ruby", "rt", "rp", "table", "thead", "tbody", "tfoot", "tr"]]
-    content: StructuredContent
-    data: DataAttributes
-    lang: str
+	tag: Required[Literal["ruby", "rt", "rp", "table", "thead", "tbody", "tfoot", "tr"]]
+	content: StructuredContent
+	data: DataAttributes
+	lang: str
+
 
 class TableStructContent(TypedDict, total=False):
-    tag: Required[Literal["td", "th"]]
-    content: StructuredContent
-    data: DataAttributes
-    colSpan: int
-    rowSpan: int
-    style: StyleAttributes
-    lang: str
+	tag: Required[Literal["td", "th"]]
+	content: StructuredContent
+	data: DataAttributes
+	colSpan: int
+	rowSpan: int
+	style: StyleAttributes
+	lang: str
+
 
 class StylishContainerStructContent(TypedDict, total=False):
-    tag: Required[Literal["span", "div", "ol", "ul", "li", "details", "summary"]]
-    content: StructuredContent
-    data: DataAttributes
-    style: StyleAttributes
-    # Hover text
-    title: str
-    open: bool
-    lang: str
+	tag: Required[Literal["span", "div", "ol", "ul", "li", "details", "summary"]]
+	content: StructuredContent
+	data: DataAttributes
+	style: StyleAttributes
+	# Hover text
+	title: str
+	open: bool
+	lang: str
+
 
 class ImageTagStructContent(TypedDict, total=False):
-    tag: Required[Literal["img"]]
-    data: DataAttributes
-    path: Required[str]
-    width: float
-    height: float
-    # Hover text
-    title: str
-    alt: str
-    description: str
-    pixelated: bool
-    imageRendering: Literal["auto", "pixelated", "crisp=edges"]
-    appearance: Literal["auto", "monochrome"]
-    background: bool
-    collapsed: bool
-    collapsible: bool
-    verticalAlign: Literal["baseline", "sub", "super", "text-top", "text-bottom", "middle", "top", "bottom"]  # noqa: E501
-    border: str
-    borderRadius: str
-    # The units for the width and height
-    sizeUnits: Literal["px", "em"]
+	tag: Required[Literal["img"]]
+	data: DataAttributes
+	path: Required[str]
+	width: float
+	height: float
+	# Hover text
+	title: str
+	alt: str
+	description: str
+	pixelated: bool
+	imageRendering: Literal["auto", "pixelated", "crisp=edges"]
+	appearance: Literal["auto", "monochrome"]
+	background: bool
+	collapsed: bool
+	collapsible: bool
+	verticalAlign: Literal[
+		"baseline", "sub", "super", "text-top", "text-bottom", "middle", "top", "bottom"
+	]  # noqa: E501
+	border: str
+	borderRadius: str
+	# The units for the width and height
+	sizeUnits: Literal["px", "em"]
+
 
 class LinkTagStructContent(TypedDict, total=False):
-    tag: Required[Literal["a"]]
-    content: StructuredContent
-    href: Required[str]
-    lang: str
+	tag: Required[Literal["a"]]
+	content: StructuredContent
+	href: Required[str]
+	lang: str

--- a/pyglossary/plugins/yomichan/types.py
+++ b/pyglossary/plugins/yomichan/types.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Literal, TypeAlias, Union
+
+from typing_extensions import NotRequired, Required, TypedDict
+
+DefinitionObj: TypeAlias = Union[
+    "DefinitionString",
+    "DefinitionImage",
+    "DefinitionStructContent",
+]
+YomichanDefinition: TypeAlias = str | DefinitionObj | tuple[str, list[str]]
+
+class DefinitionString(TypedDict):
+    type: Literal["text"]
+    text: str
+
+class DefinitionImage(TypedDict, total=False):
+    type: Required[Literal["image"]]
+    path: Required[str]
+    width: int
+    height: int
+    title: str
+    alt: str
+    description: str
+    pixelated: bool
+    imageRendering: Literal["auto", "pixelated", "crisp=edges"]
+    appearance: Literal["auto", "monochrome"]
+    background: bool
+    collapsed: bool
+    collapsible: bool
+
+class DefinitionStructContent(TypedDict):
+    type: Literal["structured-content"]
+    content: StructuredContent
+
+StructuredContent: TypeAlias = Union[
+    str,
+    list["StructuredContent"],
+    "StructuredContentObj",
+]
+
+StructuredContentObj: TypeAlias = Union[
+    "EmptyTagStructContent",
+    "GenericContainerStructContent",
+    "TableStructContent",
+    "StylishContainerStructContent",
+    "ImageTagStructContent",
+    "LinkTagStructContent",
+]
+DataAttributes: TypeAlias = dict[str, str]
+StyleAttributes: TypeAlias = dict[str, str]
+
+class EmptyTagStructContent(TypedDict):
+    tag: Literal["br"]
+    data: NotRequired[DataAttributes]
+
+class GenericContainerStructContent(TypedDict, total=False):
+    tag: Required[Literal["ruby", "rt", "rp", "table", "thead", "tbody", "tfoot", "tr"]]
+    content: StructuredContent
+    data: DataAttributes
+    lang: str
+
+class TableStructContent(TypedDict, total=False):
+    tag: Required[Literal["td", "th"]]
+    content: StructuredContent
+    data: DataAttributes
+    colSpan: int
+    rowSpan: int
+    style: StyleAttributes
+    lang: str
+
+class StylishContainerStructContent(TypedDict, total=False):
+    tag: Required[Literal["span", "div", "ol", "ul", "li", "details", "summary"]]
+    content: StructuredContent
+    data: DataAttributes
+    style: StyleAttributes
+    # Hover text
+    title: str
+    open: bool
+    lang: str
+
+class ImageTagStructContent(TypedDict, total=False):
+    tag: Required[Literal["img"]]
+    data: DataAttributes
+    path: Required[str]
+    width: float
+    height: float
+    # Hover text
+    title: str
+    alt: str
+    description: str
+    pixelated: bool
+    imageRendering: Literal["auto", "pixelated", "crisp=edges"]
+    appearance: Literal["auto", "monochrome"]
+    background: bool
+    collapsed: bool
+    collapsible: bool
+    verticalAlign: Literal["baseline", "sub", "super", "text-top", "text-bottom", "middle", "top", "bottom"]  # noqa: E501
+    border: str
+    borderRadius: str
+    # The units for the width and height
+    sizeUnits: Literal["px", "em"]
+
+class LinkTagStructContent(TypedDict, total=False):
+    tag: Required[Literal["a"]]
+    content: StructuredContent
+    href: Required[str]
+    lang: str


### PR DESCRIPTION
## Description

I know that's maybe not a very requested feature but because I had a problem with converting my own collection of yomichan formatted dictionaries I wrote an plugin extension.

## Questions

 - Is there any possible way to properly implement progress bar if dictionary length is unknown until we read it fully?
 - Are there any metadata (like `plugins-meta/index.json`) that also need to be updated? 
 - I guess code style is differs from original code, isn't it? Any moments that I need to fix?

## Limitations

Supports only dictionaries of 3 version and don't implement any interactions with tags or kanji banks.

I haven't found a contribution guideline so if I have missed anything, please let me know.

Closes #622.