### PR TITLE
migrate to modern logger interface

### DIFF
--- a/pyglossary/plugins/quickdic6/writer.py
+++ b/pyglossary/plugins/quickdic6/writer.py
@@ -72,7 +72,7 @@ class Writer:
 			if entry is None:
 				break
 			if entry.isData():
-				log.warn(f"Ignoring binary data entry {entry.l_word[0]}")
+				log.warning(f"Ignoring binary data entry {entry.l_word[0]}")
 				continue
 
 			entry.detectDefiFormat()


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```