### PR TITLE
html dir writer: ensure links are correct on same page

### DIFF
--- a/pyglossary/plugins/html_dir/writer.py
+++ b/pyglossary/plugins/html_dir/writer.py
@@ -199,8 +199,6 @@ class Writer:
 				targetNew = ""
 			else:
 				targetFilename, targetEntryIndex = fileByWord[target][0]
-				if targetFilename == filename:
-					continue
 				targetNew = f"{targetFilename}#entry{targetEntryIndex}"
 			file = getLinksByFile(int(fileIndexStr))
 			file.write(


### PR DESCRIPTION
Currently the html_dir writer skips processing links if the filenames are on the same page. However, it is still necessary to link to the correct anchor on the page. This ensures that the links are still correctly processed.

I discovered this while processing a small number of entries linking to each other when testing #679.