### PR TITLE
ui.progressbar.widgets: don't set __all__ manually

### DIFF
--- a/pyglossary/ui/progressbar/widgets.py
+++ b/pyglossary/ui/progressbar/widgets.py
@@ -37,7 +37,6 @@ except ImportError:
 else:
     AbstractWidget = ABCMeta('AbstractWidget', (object,), {})
 
-__all__ = ['WidgetHFill', 'Percentage', 'UnknownLength', 'ljust', 'Bar', 'rjust']
 
 class UnknownLength:
     pass


### PR DESCRIPTION
Fixes this issue for me when trying to convert without opening the GUI/web UI or the CMD ui:

```
[CRITICAL] Traceback (most recent call last):
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/ui_cmd.py", line 216, in progressInit
    from .pbar_tqdm import createProgressBar
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/pbar_tqdm.py", line 7, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/bin/.pyglossary-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/main.py", line 313, in main
    sys.exit(mainNoExit(sys.argv))
             ~~~~~~~~~~^^^^^^^^^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/main.py", line 291, in mainNoExit
    ok = run(
        inputFilename=res.inputFilename,
    ...<8 lines>...
        glossarySetAttrs=None,
    )
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/ui_cmd.py", line 346, in run
    finalOutputFile = self.glos.convert(
        ConvertArgs(
    ...<7 lines>...
        ),
    )
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/glossary_v2.py", line 1283, in convert
    return self.convertV2(args)
           ~~~~~~~~~~~~~~^^^^^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/glossary_v2.py", line 1248, in convertV2
    finalOutputFile = self._write(
        outputFilename,
    ...<2 lines>...
        **writeOptions,
    )
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/glossary_v2.py", line 994, in _write
    self._writeEntries(writerList, filename, options)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/glossary_v2.py", line 934, in _writeEntries
    for entry in self:
                 ^^^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/glossary_v2.py", line 429, in _readersEntryGen
    self.progressInit("Converting")
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/glossary_progress.py", line 47, in progressInit
    self._ui.progressInit(*args)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/ui_cmd.py", line 218, in progressInit
    from .pbar_legacy import createProgressBar
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/pbar_legacy.py", line 3, in <module>
    from . import progressbar as pb
  File "/nix/store/9q6gmgv0hz6xw1dml18yppb51fjrw0xk-python3.13-pyglossary-5.1.1/lib/python3.13/site-packages/pyglossary/ui/progressbar/__init__.py", line 50, in <module>
    from .widgets import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pyglossary.ui.progressbar.widgets' has no attribute 'ljust'
```

However, I'd recommend simply making `tqdm` a mandatory dependency. 
