### PR TITLE
build-macos.yml: skip install of ootb dependencies

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install brew dependencies
         run: |
-          brew install libffi gettext cmake pkg-config icu4c lzo
+          brew install libffi icu4c
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
- Remove ootb brew dependencies already available in the ootb images:

> `macos-13`
- https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

> `macos-14`
- https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md

> `macos-15`
- https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md