### PR TITLE
improved detectLangsFromName()

### DIFF
--- a/pyglossary/glossary_info.py
+++ b/pyglossary/glossary_info.py
@@ -195,15 +195,33 @@ class GlossaryInfo:
 		langNames = []
 
 		def checkPart(part: str) -> None:
-			for match in re.findall(r"\w\w\w*", part):
-				# print(f"{match = }")
-				lang = langDict[match]
-				if lang is None:
-					continue
+			lang = langDict[part]
+			if lang is not None:
 				langNames.append(lang.name)
+			else:
+				for match in re.findall(r"\w\w\w*", part):
+					# print(f"{match = }")
+					lang = langDict[match]
+					if lang is None:
+						continue
+					langNames.append(lang.name)
 
-		for part in re.split("-| to ", name):
-			# print(f"{part = }")
+
+		def split_once_last(name):
+			# we assume that the last occurrence of - or to, separates the languages.
+			# Note: This way we prevent errors that occur for example with "Neo-Persian to English.."
+			# However, we still get wrong results when it is something like "en - Neo-Persian"
+			# We cannot uniquely identify the users will when resorting to this function anyway.
+			# This way however improves results to a great extent
+
+			# reverse string and splitter patterns, perform at most one split, then reverse parts back
+			rev = name[::-1]
+			# pattern reversed: '-' stays '-', ' to ' becomes ' ot '
+			parts = re.split(r'-| ot ', rev, maxsplit=1)
+			return [p[::-1] for p in parts[::-1]]
+
+		for part in split_once_last( name):
+			#print(f"{part = }")
 			checkPart(part)
 			if len(langNames) >= 2:  # noqa: PLR2004
 				break

--- a/tests/glossary_v2_test.py
+++ b/tests/glossary_v2_test.py
@@ -584,6 +584,25 @@ class TestGlossary(TestGlossaryBase):
 			("English", "German"),
 		)
 
+	def test_lang_detect_6(self):
+		glos = self.glos = Glossary()
+		glos.setInfo("name", "Church Slavonic-deu.index")
+		glos.detectLangsFromName()
+		print(glos.sourceLangName)
+		self.assertEqual(
+			(glos.sourceLangName, glos.targetLangName),
+			("Church Slavonic", "German"),
+		)
+	def test_lang_detect_7(self):
+		glos = self.glos = Glossary()
+		glos.setInfo("name", "Na vosa vaka-Viti-deu.index")
+		glos.detectLangsFromName()
+		print(glos.sourceLangName)
+		self.assertEqual(
+			(glos.sourceLangName, glos.targetLangName),
+			("Fijian", "German"),
+		)
+
 	def convert_to_txtZip(
 		self,
 		fname,  # input file with extension


### PR DESCRIPTION
improved **detectLangsFromName**

and added tests 

test_lang_detect_6 
test_lang_detect_7 

with tests that used to fail before, but now with the new detectLangsFromName pass.

Details:
Now  we assume that the last occurrence of - or to, separates the target from source language. Note: This way we prevent errors that occur for example with "Neo-Persian to English.." However, we still get wrong results when it is something like "en - Neo-Persian" We cannot uniquely identify the users will when resorting to this function anyway. This way however improves results to a great extent