### PR TITLE
slob writer: fix typo in slash replacement

### DIFF
--- a/pyglossary/plugins/aard2_slob/writer.py
+++ b/pyglossary/plugins/aard2_slob/writer.py
@@ -201,7 +201,7 @@ class Writer:
 					b"""onclick="new Audio(this.href).play(); return false;" href='""",
 				)
 				b_defi = b_defi.replace(b"""<img src="/""", b'''<img src="''')
-				b_defi = b_defi.replace(b"""<img src='""", b"""<img src='""")
+				b_defi = b_defi.replace(b"""<img src='/""", b"""<img src='""")
 				b_defi = b_defi.replace(b"""<img src="file:///""", b'''<img src="''')
 				b_defi = b_defi.replace(b"""<img src='file:///""", b"""<img src='""")
 


### PR DESCRIPTION
add missing slash in replacement (as it was originally intended); current code is replacing with the same string (no-op)