### PR TITLE
macos gtk4: fix no attribute display.get_primary_monitor()

### DIFF
--- a/pyglossary/ui/ui_gtk4/mainwin.py
+++ b/pyglossary/ui/ui_gtk4/mainwin.py
@@ -131,8 +131,14 @@ def getFontSizePixels(widget: gtk.Widget) -> int:
 
 	# Get DPI from monitor (fallback = 96.0)
 	display = widget.get_display()
-	monitor = display.get_primary_monitor()
-	scale = monitor.get_scale_factor()
+	monitor = None
+	try:
+		monitor = display.get_primary_monitor()
+	except AttributeError:
+		monitors = display.get_monitors()
+		if monitors and len(monitors) > 0:
+			monitor = monitors[0]
+	scale = monitor.get_scale_factor() if monitor else 1
 	dpi = 96.0 * scale  # GTK doesn’t expose real DPI anymore — approximate
 
 	return font_size_points * dpi / 72.0

--- a/pyglossary/ui/ui_gtk4/utils.py
+++ b/pyglossary/ui/ui_gtk4/utils.py
@@ -45,11 +45,17 @@ __all__ = [
 
 def getWorkAreaSize(_w: object) -> tuple[int, int]:
 	display = gdk.Display.get_default()
-	# monitor = display.get_monitor_at_surface(w.get_surface())
-	# if monitor is None:
-	monitor = display.get_primary_monitor()
-	rect = monitor.get_workarea()
-	return rect.width, rect.height
+	monitor = None
+	try:
+		monitor = display.get_primary_monitor()
+	except AttributeError:
+		monitors = display.get_monitors()
+		if monitors and len(monitors) > 0:
+			monitor = monitors[0]
+	if monitor is None:
+		return 1024, 768
+	geometry = monitor.get_geometry()
+	return geometry.width, geometry.height
 
 
 def gtk_event_iteration_loop() -> None:


### PR DESCRIPTION
Summary
------
Fix for macos GTK4: add fallback for `AttributeError: 'GdkMacosDisplay' object has no attribute 'get_primary_monitor'`

pyglossary version - current `master`:

```sh
git describe
5.3.0-86-g936c7d8b
```

invocation command line:

```sh
python3 main.py --gtk4
```

pr fixes the following error on macos:

```pytb
[CRITICAL] Traceback (most recent call last):
  File "~/projects/python/pyglossary/pyglossary/ui/ui_gtk4/ui.py", line 72, in do_activate
    self.mainWindow = MainWindow(
                      ~~~~~~~~~~^
    	ui=self,
     ^^^^^^^^
    	app=self,
     ^^^^^^^^^
    	progressBar=self.progressBar,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "~/projects/python/pyglossary/pyglossary/ui/ui_gtk4/mainwin.py", line 214, in __init__
    screenW, screenH = getWorkAreaSize(self)
                       ~~~~~~~~~~~~~~~^^^^^^
  File "~/projects/python/pyglossary/pyglossary/ui/ui_gtk4/utils.py", line 60, in getWorkAreaSize
    rect = monitor.get_workarea()
           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'GdkMacosMonitor' object has no attribute 'get_workarea'
```

GTK4 installed via homebrew with `brew install gtk4`:

```sh
brew info gtk4
==> gtk4 ✔: stable 4.22.1 (bottled), HEAD
Toolkit for creating graphical user interfaces
https://gtk.org/
Installed
/opt/homebrew/Cellar/gtk4/4.22.1 (643 files, 78.4MB) *
  Poured from bottle using the formulae.brew.sh API on 2026-05-21 at 11:27:21
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/gtk4.rb
License: LGPL-2.1-or-later
```

NOTE
====
Did not test for regressions on Windows and Linux or older/newer macos versions + older/newer GTK4 versions. GTK3 still works with `python3 main.py --gtk`.