### PR TITLE
csv reader: allow reading resources with nested subdirs

### DIFF
--- a/pyglossary/plugins/csv_plugin/reader.py
+++ b/pyglossary/plugins/csv_plugin/reader.py
@@ -20,8 +20,8 @@
 from __future__ import annotations
 
 import csv
-import os
-from os.path import isdir, join
+from os.path import isdir
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from pyglossary.compress import (
@@ -98,7 +98,7 @@ class Reader:
 		)
 		self._resDir = filename + "_res"
 		if isdir(self._resDir):
-			self._resFileNames = os.listdir(self._resDir)
+			self._resFileNames = Path(self._resDir).rglob("*")
 		else:
 			self._resDir = ""
 			self._resFileNames = []
@@ -176,10 +176,15 @@ class Reader:
 
 		self._entryCount = entryCount
 
-		resDir = self._resDir
-		for fname in self._resFileNames:
-			with open(join(resDir, fname), "rb") as file:
-				yield self._glos.newDataEntry(
-					fname,
-					file.read(),
-				)
+		resDirPath = Path(self._resDir)
+
+		resFilePath: Path
+		for resFilePath in self._resFileNames:
+			if resFilePath.is_file():
+				with resFilePath.open(mode="rb") as file:
+					yield self._glos.newDataEntry(
+						resFilePath.relative_to(resDirPath).as_posix(),
+						file.read(),
+					)
+			else:
+				log.debug(f"ResourceDir: {resFilePath.absolute()}")

--- a/pyglossary/plugins/edlin/reader.py
+++ b/pyglossary/plugins/edlin/reader.py
@@ -65,6 +65,7 @@ class Reader:
 
 		self._resDir = join(filename, "res")
 		if isdir(self._resDir):
+			# TODO: FIXME: use recursive traversal
 			self._resFileNames = os.listdir(self._resDir)
 		else:
 			self._resDir = ""

--- a/pyglossary/plugins/gettext_po/reader.py
+++ b/pyglossary/plugins/gettext_po/reader.py
@@ -42,6 +42,7 @@ class Reader:
 		self._file = open(filename, encoding="utf-8")
 		self._resDir = filename + "_res"
 		if isdir(self._resDir):
+			# TODO: FIXME: use recursive traversal
 			self._resFileNames = os.listdir(self._resDir)
 		else:
 			self._resDir = ""

--- a/pyglossary/plugins/stardict/reader.py
+++ b/pyglossary/plugins/stardict/reader.py
@@ -124,6 +124,7 @@ class Reader:
 			self._dictFile = open(self._filename + ".dict", mode="rb")
 		self._resDir = join(dirname(self._filename), "res")
 		if isdir(self._resDir):
+			# TODO: FIXME: use recursive traversal
 			self._resFileNames = os.listdir(self._resDir)
 		else:
 			self._resDir = ""


### PR DESCRIPTION
## Summary
- CSV reader: fix exception when `..._res` folder contains nested subfolders

### steps to reproduce

1. convert a dictionary with resources with nested subdirs to `.csv` 
2. convert the generated `.csv` to a format that supports resources, e.g. `.slob` 

traceback
```pytb
python3 main.py ldoce6.csv ldoce6.slob
[INFO] compressionOpen: kwargs={'mode': 'rt', 'encoding': 'utf-8', 'newline': '\n'}
[INFO] Writing to Aard2Slob file 'ldoce6.slob'
[INFO] Finalizing slob file...
[INFO] Finalizing slob file took 0.0 seconds
[CRITICAL] Traceback (most recent call last):
  File "~/projects/pyglossary/main.py", line 10, in <module>
    main()
    ~~~~^^
  File "~/projects/pyglossary/pyglossary/ui/main.py", line 318, in main
    sys.exit(mainNoExit(sys.argv))
             ~~~~~~~~~~^^^^^^^^^^
  File "~/projects/pyglossary/pyglossary/ui/main.py", line 296, in mainNoExit
    ok = run(
    	inputFilename=res.inputFilename,
    ...<8 lines>...
    	glossarySetAttrs=None,
    )
  File "~/projects/pyglossary/pyglossary/ui/ui_cmd.py", line 357, in run
    finalOutputFile = self.glos.convert(
    	ConvertArgs(
    ...<7 lines>...
    	),
    )
  File "~/projects/pyglossary/pyglossary/glossary_v2.py", line 1288, in convert
    return self.convertV2(args)
           ~~~~~~~~~~~~~~^^^^^^
  File "~/projects/pyglossary/pyglossary/glossary_v2.py", line 1253, in convertV2
    finalOutputFile = self._write(
    	outputFilename,
    ...<2 lines>...
    	**writeOptions,
    )
  File "~/projects/pyglossary/pyglossary/glossary_v2.py", line 996, in _write
    self._writeEntries(writerList, filename, options)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/projects/pyglossary/pyglossary/glossary_v2.py", line 933, in _writeEntries
    for entry in self:
                 ^^^^
  File "~/projects/pyglossary/pyglossary/glossary_v2.py", line 440, in _readersEntryGen
    yield from iterator
  File "~/projects/pyglossary/pyglossary/glossary_v2.py", line 455, in _applyEntryFiltersGen
    for entry in iterable:
                 ^^^^^^^^
  File "~/projects/pyglossary/pyglossary/glossary_progress.py", line 66, in _byteProgressIter
    for entry in iterable:
                 ^^^^^^^^
  File "~/projects/pyglossary/pyglossary/plugins/csv_plugin/reader.py", line 181, in __iter__
    with open(join(resDir, fname), "rb") as file:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: 'ldoce6.csv_res/hwd'

```

## NOTE
Several other readers seem to have the same issue

 - they use `os.listdir()` rather than traversing the subdirs recursively. I have marked them with `TODO: FIXME` in order to sync on a clean approach how to handle them too without duplicating the code, although I don't see any issue with duplicating the code, so that the plugins can be standalone. 
 - Leaving `os.listdir()` and skipping folders would not be a correct solution since that will ignore nested resources, and they should not be skipped.

partial sample from the dictionary:

:paperclip: [ldoce6.csv.zip](https://github.com/user-attachments/files/28355193/ldoce6.csv.zip)

as can be seen from the source the assets are not immediate children of `resDir`:

```html 
<a href="sound://exa/bre/d/p008-001818160.ogg">
```