### PR TITLE
webui: add file picker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,16 +53,16 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: python3 scripts/ci/coverage-pr-comment.py
-      - name: Post coverage PR comment
-        if: >-
-          always() &&
-          github.event_name == 'pull_request' &&
-          matrix.python-version == '3.12' &&
-          steps.coverage.outputs.coverage_comment_ready == 'true'
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: artifacts/coverage/pr-comment.md
+      # - name: Post coverage PR comment
+      #   if: >-
+      #     always() &&
+      #     github.event_name == 'pull_request' &&
+      #     matrix.python-version == '3.12' &&
+      #     steps.coverage.outputs.coverage_comment_ready == 'true'
+      #   uses: peter-evans/create-or-update-comment@v4
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     body-path: artifacts/coverage/pr-comment.md
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         run: bash scripts/ci/test.sh
       - name: Collect coverage reports
-        if: never() && matrix.python-version == '3.12'
+        if: always() && matrix.python-version == '3.12'
         run: bash scripts/ci/collect-coverage.sh
       - name: Compare coverage on PR
         id: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         run: bash scripts/ci/test.sh
       - name: Collect coverage reports
-        if: always() && matrix.python-version == '3.12'
+        if: never() && matrix.python-version == '3.12'
         run: bash scripts/ci/collect-coverage.sh
       - name: Compare coverage on PR
         id: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ on:
     - cron: "33 1 * * 3"
   workflow_dispatch:
 
+
 jobs:
   ubuntu:
     name: Test on Ubuntu
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     strategy:
       fail-fast: false
@@ -60,7 +62,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-tag: pyglossary-coverage
           body-path: artifacts/coverage/pr-comment.md
       - name: Upload test artifacts
         if: always()

--- a/pyglossary/ui/argparse_main.py
+++ b/pyglossary/ui/argparse_main.py
@@ -45,7 +45,7 @@ def defineFlags(parser: argparse.ArgumentParser, config: ConfigType) -> None:
 		"-u",
 		"--ui",
 		dest="ui_type",
-		default="auto",
+		default="tk",
 		choices=(
 			"cmd",
 			"gtk",

--- a/pyglossary/ui/argparse_main.py
+++ b/pyglossary/ui/argparse_main.py
@@ -45,7 +45,7 @@ def defineFlags(parser: argparse.ArgumentParser, config: ConfigType) -> None:
 		"-u",
 		"--ui",
 		dest="ui_type",
-		default="tk",
+		default="auto",
 		choices=(
 			"cmd",
 			"gtk",

--- a/pyglossary/ui/ui_web/browse.html
+++ b/pyglossary/ui/ui_web/browse.html
@@ -190,90 +190,6 @@
 						/>
 						<select id="inputFormat" name="inputFormat">
 							<option value=""></option>
-							<option value="Aard2Slob">Aard 2 (.slob)</option>
-							<option value="ABBYYLingvoDSL">
-								ABBYY Lingvo DSL (.dsl)
-							</option>
-							<option value="ABCMedicalNotes">
-								ABC Medical Notes (SQLite3)
-							</option>
-							<option value="Almaany">
-								Almaany.com (SQLite3)
-							</option>
-							<option value="AppleDictBin">
-								AppleDict Binary
-							</option>
-							<option value="AyanDictSQLite">
-								AyanDict SQLite
-							</option>
-							<option value="BabylonBgl">Babylon (.BGL)</option>
-							<option value="cc-kedict">cc-kedict</option>
-							<option value="CrawlerDir">
-								Crawler Directory
-							</option>
-							<option value="Csv">CSV (.csv)</option>
-							<option value="Dictcc">Dict.cc (SQLite3)</option>
-							<option value="Dictcc_split">
-								Dict.cc (SQLite3) - Split
-							</option>
-							<option value="DictOrg">
-								DICT.org file format (.index)
-							</option>
-							<option value="Dicformids">
-								DictionaryForMIDs
-							</option>
-							<option value="Dictunformat">
-								dictunformat output file
-							</option>
-							<option value="DigitalNK">
-								DigitalNK (SQLite3, N-Korean)
-							</option>
-							<option value="EDICT2">
-								EDICT2 (CEDICT) (.u8)
-							</option>
-							<option value="Edlin">EDLIN</option>
-							<option value="FreeDict">FreeDict (.tei)</option>
-							<option value="GettextPo">
-								Gettext Source (.po)
-							</option>
-							<option value="Info">Glossary Info (.info)</option>
-							<option value="JMDict">JMDict (xml)</option>
-							<option value="JMnedict">JMnedict</option>
-							<option value="Dictfile">
-								Kobo E-Reader Dictfile (.df)
-							</option>
-							<option value="LingoesLDF">
-								Lingoes Source (.ldf)
-							</option>
-							<option value="OctopusMdict">
-								Octopus MDict (.mdx)
-							</option>
-							<option value="QuickDic6">
-								QuickDic version 6 (.quickdic)
-							</option>
-							<option value="Stardict">StarDict (.ifo)</option>
-							<option value="StardictTextual">
-								StarDict Textual File (.xml)
-							</option>
-							<option value="Tabfile">
-								Tabfile (.txt, .dic)
-							</option>
-							<option value="Test">
-								Test Format File(.test)
-							</option>
-							<option value="Wiktextract">
-								Wiktextract (.jsonl)
-							</option>
-							<option value="Wordnet">WordNet</option>
-							<option value="Wordset">
-								Wordset.org JSON directory
-							</option>
-							<option value="Xdxf">XDXF (.xdxf)</option>
-							<option value="XdxfLax">XDXF Lax (.xdxf)</option>
-							<option value="XdxfCss">
-								XDXF with CSS and JS
-							</option>
-							<option value="Zim">Zim (.zim, for Kiwix)</option>
 						</select>
 						<input
 							type="text"
@@ -290,12 +206,45 @@
 		<script>
 			const status = document.getElementById("status");
 
+			// unix-style permissions, must match server-side READ/WRITE flags
+			const CAN = {
+				READ: 1,  // 0b01
+				WRITE: 2, // 0b10
+			};
+
 			function log(msg, title) {
 				console.log(msg);
 				status.innerHTML = msg;
 				if (title) {
 					status.title = title;
 				}
+			}
+
+			function loadConfig() {
+				return fetch("/config")
+					.then((response) => {
+						if (!response.ok) {
+							log(`Failed to fetch configuration: ${response.status} ${response.statusText}`);
+							return Promise.reject(`Failed to fetch configuration: ${response.statusText}`);
+						}
+						return response.json();
+					})
+					.then((formats) => {
+						window.formats = formats;
+						const fragment = document.createDocumentFragment();
+						Object.keys(formats)
+							.sort((a, b) => formats[a].desc.localeCompare(formats[b].desc))
+							.forEach((key) => {
+								const plug = formats[key];
+								if (plug.can & CAN.READ) {
+									fragment.appendChild(new Option(plug.desc, key));
+								}
+							});
+						form.inputFormat.appendChild(fragment);
+					})
+					.catch((error) => {
+						log(`Error populating format dropdown: ${error}`);
+					});
 			}
 
 			window.onload = function () {
@@ -306,10 +255,15 @@
 				form.word.value = params.get("word");
 				form.path.value = form.path.value || params.get("path");
 				form.max.value = params.get("max");
-				form.inputFormat.value = params.get("format");
 
 				attachEventListeners(form);
 				initWsConnection();
+
+				// populate the format dropdown from the server, then restore
+				// the value from the URL ?format=... parameter (if any)
+				loadConfig().then(() => {
+					form.inputFormat.value = params.get("format") || "";
+				});
 			};
 
 			function attachEventListeners() {

--- a/pyglossary/ui/ui_web/index.html
+++ b/pyglossary/ui/ui_web/index.html
@@ -792,12 +792,13 @@
                 const reqId = ++listDirSeq;
                 listDirCallbacks.set(reqId, { resolve, reject });
                 sendListDir(reqId, target, path, showHidden);
+                // timeout safety
                 setTimeout(() => {
                     if (listDirCallbacks.has(reqId)) {
                         listDirCallbacks.delete(reqId);
                         reject(new Error('listDir timeout'));
                     }
-                }, 8000);
+                }, 5000);
             });
         }
 

--- a/pyglossary/ui/ui_web/index.html
+++ b/pyglossary/ui/ui_web/index.html
@@ -352,10 +352,10 @@
                     <summary>&#9432; How to convert a dictionary?</summary>
                     <p>
                     <ol>
-                        <li>Paste the full path to a dictionary file on your local file system in the <b>Input file</b>
-                            field.</li>
+                        <li>Click &#128193; or type in the <b>Input file</b>
+                            field to select the source file.</li>
                         <li>Select input file format if not detected automatically.</li>
-                        <li>Paste the full path to the converted file in the <b>Output file</b> field.</li>
+                        <li>Click &#128193; or type in the <b>Output file</b> field to pick the output file.</li>
                         <li>Select a <a target="_blank"
                                 href="https://github.com/ilius/pyglossary?tab=readme-ov-file#supported-formats">target
                                 format</a> to convert to</li>

--- a/pyglossary/ui/ui_web/index.html
+++ b/pyglossary/ui/ui_web/index.html
@@ -838,46 +838,74 @@
         // ---------------- Autocomplete ----------------
         let acState = {
             input: null,
-            reqId: 0,
             entries: [],
+            filtered: [],
             active: -1,
             lastDir: null,
+            lastInputId: null,
+            reqSeq: 0,
             debounce: null,
+            blurTimer: null,
         };
         const acDropdown = document.getElementById('acDropdown');
 
         function initAutocomplete() {
             ['inputFilename', 'outputFilename'].forEach(id => {
                 const el = document.getElementById(id);
-                el.addEventListener('focus', () => maybeShowAutocomplete(el));
+                el.addEventListener('focus', () => {
+                    // Cancel any pending blur-hide from a previous input
+                    clearTimeout(acState.blurTimer);
+                    maybeShowAutocomplete(el);
+                });
                 el.addEventListener('input', () => {
                     clearTimeout(acState.debounce);
-                    acState.debounce = setTimeout(() => maybeShowAutocomplete(el), 150);
+                    acState.debounce = setTimeout(() => maybeShowAutocomplete(el), 120);
                 });
                 el.addEventListener('keydown', e => onAutocompleteKeydown(e));
                 el.addEventListener('blur', () => {
                     // delay so click on a suggestion registers
-                    setTimeout(hideAutocomplete, 200);
+                    acState.blurTimer = setTimeout(hideAutocomplete, 200);
                 });
             });
-            document.addEventListener('scroll', hideAutocomplete, true);
-            window.addEventListener('resize', hideAutocomplete);
+            // Reposition on window scroll; hide on scroll of other elements
+            // but NEVER on scroll inside the dropdown itself
+            document.addEventListener('scroll', (e) => {
+                if (acDropdown.classList.contains('hidden')) return;
+                if (e.target === acDropdown || acDropdown.contains(e.target)) return;
+                if (e.target === document || e.target === document.documentElement || e.target === document.body || e.target === window) {
+                    repositionAutocomplete();
+                } else {
+                    hideAutocomplete();
+                }
+            }, true);
+            window.addEventListener('resize', () => {
+                if (!acDropdown.classList.contains('hidden')) repositionAutocomplete();
+            });
         }
 
         async function maybeShowAutocomplete(inputEl) {
             acState.input = inputEl;
+            acState.lastInputId = inputEl.id;
             const { dir, prefix } = splitPathForAutocomplete(inputEl.value);
-            if (acState.lastDir !== dir) {
+
+            // Track the request sequence to avoid stale responses overwriting state
+            const reqSeq = ++acState.reqSeq;
+
+            if (acState.lastDir !== dir || acState.lastInputId !== inputEl.id) {
                 acState.lastDir = dir;
+                acState.lastInputId = inputEl.id;
                 acState.entries = [];
                 try {
                     const resp = await requestListDir(inputEl.id, dir, pickerShowHidden());
+                    // Guard against stale responses from a previous input/dir
+                    if (reqSeq !== acState.reqSeq || acState.input !== inputEl) return;
                     acState.entries = resp.entries || [];
                 } catch (e) {
-                    hideAutocomplete();
+                    if (reqSeq === acState.reqSeq && acState.input === inputEl) hideAutocomplete();
                     return;
                 }
             }
+            if (reqSeq !== acState.reqSeq || acState.input !== inputEl) return;
             renderAutocomplete(prefix, inputEl);
         }
 
@@ -891,7 +919,8 @@
             }
             acState.active = -1;
             acDropdown.innerHTML = '';
-            filtered.slice(0, 200).forEach((e, i) => {
+            const max = 200;
+            filtered.slice(0, max).forEach((e, i) => {
                 const li = document.createElement('li');
                 li.className = e.isDir ? 'dir' : '';
                 li.textContent = (e.isDir ? '\uD83D\uDCC1 ' : '\uD83D\uDCC4 ') + e.name;
@@ -903,12 +932,18 @@
                 acDropdown.appendChild(li);
             });
             acState.filtered = filtered;
-            positionAutocomplete(inputEl);
+            repositionAutocomplete();
             acDropdown.classList.remove('hidden');
         }
 
-        function positionAutocomplete(inputEl) {
+        function repositionAutocomplete() {
+            const inputEl = acState.input;
+            if (!inputEl) return;
             const r = inputEl.getBoundingClientRect();
+            if (r.bottom === 0 && r.top === 0) {
+                hideAutocomplete();
+                return;
+            }
             acDropdown.style.top = (window.scrollY + r.bottom + 2) + 'px';
             acDropdown.style.left = (window.scrollX + r.left) + 'px';
             acDropdown.style.minWidth = r.width + 'px';
@@ -918,6 +953,7 @@
             acDropdown.classList.add('hidden');
             acDropdown.innerHTML = '';
             acState.active = -1;
+            acState.filtered = [];
         }
 
         function acceptAutocomplete(entry) {
@@ -938,16 +974,24 @@
         }
 
         function onAutocompleteKeydown(e) {
-            if (acDropdown.classList.contains('hidden')) return;
             const list = acState.filtered;
+            // If dropdown is hidden, ArrowDown should reopen it
+            if (acDropdown.classList.contains('hidden')) {
+                if (e.key === 'ArrowDown' && acState.input === e.target) {
+                    e.preventDefault();
+                    maybeShowAutocomplete(e.target);
+                }
+                return;
+            }
             if (!list || !list.length) return;
+            const count = Math.min(list.length, 200);
             if (e.key === 'ArrowDown') {
                 e.preventDefault();
-                acState.active = (acState.active + 1) % Math.min(list.length, 200);
+                acState.active = acState.active < 0 ? 0 : (acState.active + 1) % count;
                 updateAcActive();
             } else if (e.key === 'ArrowUp') {
                 e.preventDefault();
-                acState.active = (acState.active - 1 + Math.min(list.length, 200)) % Math.min(list.length, 200);
+                acState.active = acState.active < 0 ? count - 1 : (acState.active - 1 + count) % count;
                 updateAcActive();
             } else if (e.key === 'Enter' || e.key === 'Tab') {
                 if (acState.active >= 0) {
@@ -955,15 +999,30 @@
                     acceptAutocomplete(list[acState.active]);
                 }
             } else if (e.key === 'Escape') {
+                e.preventDefault();
                 hideAutocomplete();
             }
         }
 
         function updateAcActive() {
-            [...acDropdown.children].forEach((li, i) => {
-                li.classList.toggle('ac-active', i === acState.active);
-                if (i === acState.active) li.scrollIntoView({ block: 'nearest' });
-            });
+            const items = acDropdown.children;
+            for (let i = 0; i < items.length; i++) {
+                items[i].classList.toggle('ac-active', i === acState.active);
+            }
+            // Manually scroll the active item into view WITHOUT triggering
+            // a scroll event that could cascade back and dismiss the dropdown
+            if (acState.active >= 0 && items[acState.active]) {
+                const item = items[acState.active];
+                const ddTop = acDropdown.scrollTop;
+                const ddBottom = ddTop + acDropdown.clientHeight;
+                const itemTop = item.offsetTop;
+                const itemBottom = itemTop + item.offsetHeight;
+                if (itemTop < ddTop) {
+                    acDropdown.scrollTop = itemTop;
+                } else if (itemBottom > ddBottom) {
+                    acDropdown.scrollTop = itemBottom - acDropdown.clientHeight;
+                }
+            }
         }
 
         // ---------------- Modal picker ----------------

--- a/pyglossary/ui/ui_web/index.html
+++ b/pyglossary/ui/ui_web/index.html
@@ -122,6 +122,126 @@
             display: none;
             visibility: hidden;
         }
+
+        /* ---- File picker modal ---- */
+        #filePicker {
+            max-width: 640px;
+        }
+        #filePicker article {
+            max-height: 80vh;
+            display: flex;
+            flex-direction: column;
+        }
+        #pickerPath {
+            font-family: 'Fira Code', 'Fira Mono', 'Jetbrains Mono', Consolas, Monaco, Lucida Console, monospace;
+            font-size: x-small;
+        }
+        #pickerList {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            overflow-y: auto;
+            flex: 1 1 auto;
+            max-height: 50vh;
+            border: 1px solid var(--pico-muted-border-color);
+            border-radius: var(--pico-border-radius);
+            background-color: var(--pico-background-color);
+            color: var(--pico-color);
+        }
+        #pickerList li {
+            padding: 0.3rem 0.6rem;
+            cursor: pointer;
+            font-size: small;
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            color: var(--pico-color);
+            transition: background-color 0.08s ease;
+        }
+        #pickerList li.dir { font-weight: 532; }
+        #pickerList li.selected {
+            background-color: var(--pico-primary-background);
+            color: var(--pico-primary-inverse);
+        }
+        #pickerList li:hover {
+            background-color: var(--pico-dropdown-hover-background-color);
+        }
+        #pickerList li.selected:hover {
+            background-color: var(--pico-primary-hover-background);
+            color: var(--pico-primary-inverse);
+        }
+        #pickerFilter { margin: 0; }
+        #pickerNameRow { display: flex; gap: 0.5rem; align-items: center; }
+        #pickerNameRow label { margin: 0; flex: 0 0 auto; }
+        #pickerName { flex: 1; }
+        #pickerTruncated {
+            font-size: x-small;
+            color: var(--pico-muted-color);
+            padding: 0.2rem 0.6rem;
+        }
+        /* native Pico checkbox inside a plain label */
+        .pickerCheckboxRow {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            margin: 0.25rem 0;
+            font-size: small;
+        }
+        .pickerCheckboxRow input[type="checkbox"] {
+            margin: 0;
+            flex: 0 0 auto;
+        }
+        .pickerCheckboxRow label {
+            margin: 0;
+            display: inline-flex;
+            align-items: center;
+            cursor: pointer;
+        }
+
+        /* ---- Autocomplete dropdown ---- */
+        .ac-dropdown {
+            position: absolute;
+            z-index: 1000;
+            min-width: 18rem;
+            max-height: 14rem;
+            overflow-y: auto;
+            background: var(--pico-background-color);
+            color: var(--pico-color);
+            border: 1px solid var(--pico-muted-border-color);
+            border-radius: var(--pico-border-radius);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            font-size: small;
+        }
+        .ac-dropdown li {
+            padding: 0.25rem 0.5rem;
+            cursor: pointer;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: flex;
+            gap: 0.35rem;
+            align-items: center;
+            color: var(--pico-color);
+            transition: background-color 0.08s ease;
+        }
+        .ac-dropdown li.dir { font-weight: 532; }
+        .ac-dropdown li.ac-active {
+            background-color: var(--pico-primary-background);
+            color: var(--pico-primary-inverse);
+        }
+        .ac-dropdown li:hover {
+            background-color: var(--pico-dropdown-hover-background-color);
+        }
+        .ac-dropdown li.ac-active:hover {
+            background-color: var(--pico-primary-hover-background);
+            color: var(--pico-primary-inverse);
+        }
     </style>
 </head>
 
@@ -180,6 +300,7 @@
                         <select id="inputFormat" name="inputFormat" required>
                             <option></option>
                         </select>
+                        <input type="button" class="outline secondary picker-btn" data-target="inputFilename" data-mode="open" value="&#128193;" title="Browse for file">
                         <a target="_blank" class="button outline secondary browse hidden" href="/browse.html">
                             <input type="button" class="outline secondary" id="preview1" value="&#x1F50E;">
                         </a>
@@ -195,6 +316,7 @@
                         <select id="outputFormat" tabindex="-1" name="outputFormat" required>
                             <option></option>
                         </select>
+                        <input type="button" tabindex="-1" class="outline secondary picker-btn" data-target="outputFilename" data-mode="save" value="&#128193;" title="Browse for output location">
                         <a target="_blank" class="button outline secondary browse hidden" href="/browse.html">
                             <input type="button" tabindex="-1" class="outline secondary" id="preview2" value="&#x1F50E;">
                         </a>
@@ -299,6 +421,37 @@
     </dialog>
     <!-- ./ ConfigDialog -->
 
+    <!-- FilePickerDialog -->
+    <dialog id="filePicker">
+        <article>
+            <h2 id="pickerTitle">Browse</h2>
+            <fieldset role="group">
+                <input type="button" id="pickerUp" value="&#x2191; Up" class="outline secondary">
+                <input type="search" id="pickerPath" placeholder="/current/path" autocomplete="off">
+                <input type="button" id="pickerGo" value="Go" class="outline secondary">
+            </fieldset>
+            <input type="search" id="pickerFilter" placeholder="filter entries..." autocomplete="off">
+            <ul id="pickerList"></ul>
+            <div id="pickerTruncated" class="hidden"></div>
+            <div id="pickerNameRow" class="hidden">
+                <label for="pickerName">File:</label>
+                <input type="text" id="pickerName" placeholder="filename (for save)" autocomplete="off">
+            </div>
+            <div class="pickerCheckboxRow">
+                <input type="checkbox" id="pickerHidden">
+                <label for="pickerHidden">Show hidden files</label>
+            </div>
+            <footer>
+                <button id="pickerCancel" class="secondary">Cancel</button>
+                <button id="pickerChoose">Choose</button>
+            </footer>
+        </article>
+    </dialog>
+    <!-- ./ FilePickerDialog -->
+
+    <!-- Autocomplete dropdown -->
+    <ul id="acDropdown" class="ac-dropdown hidden"></ul>
+
     <script>
         document.getElementById('theme-switcher').addEventListener('click', function () {
             if (this.dataset.themeSwitcher !== 'dark') {
@@ -351,6 +504,8 @@
                     progressText.innerText = message.text;
                 } else if (message.type == 'info') {
                     log(message.text);
+                } else if (message.type == 'listDir') {
+                    handleListDirResponse(message);
                 }
             });
 
@@ -598,7 +753,400 @@
             loadConfig();
             attachListeners();
             initWsConnection();
+            initFilePicker();
+            initAutocomplete();
         };
+    </script>
+
+    <script>
+        // ---------------- File picker + autocomplete ----------------
+        const SEP = '/'; // use posix sep for display; server resolves anyway
+        const KEY_PICKER_HIDDEN = 'pg_picker_showHidden';
+        const KEY_PICKER_LASTDIR = 'pg_picker_lastDir';
+
+        // Track the single open WS so listDir requests can be sent.
+        function sendListDir(reqId, target, path, showHidden) {
+            if (!window.ws || window.ws.readyState !== WebSocket.OPEN) {
+                return false;
+            }
+            window.ws.send(JSON.stringify({
+                action: 'listDir',
+                reqId,
+                target,
+                path,
+                showHidden,
+            }));
+            return true;
+        }
+
+        // Pending listDir requests keyed by reqId -> callback
+        const listDirCallbacks = new Map();
+        let listDirSeq = 0;
+
+        function requestListDir(target, path, showHidden) {
+            return new Promise((resolve, reject) => {
+                if (!window.ws || window.ws.readyState !== WebSocket.OPEN) {
+                    reject(new Error('WebSocket not open'));
+                    return;
+                }
+                const reqId = ++listDirSeq;
+                listDirCallbacks.set(reqId, { resolve, reject });
+                sendListDir(reqId, target, path, showHidden);
+                setTimeout(() => {
+                    if (listDirCallbacks.has(reqId)) {
+                        listDirCallbacks.delete(reqId);
+                        reject(new Error('listDir timeout'));
+                    }
+                }, 8000);
+            });
+        }
+
+        function handleListDirResponse(message) {
+            const cb = listDirCallbacks.get(message.reqId);
+            if (cb) {
+                listDirCallbacks.delete(message.reqId);
+                if (message.error) cb.reject(new Error(message.error));
+                else cb.resolve(message);
+            } else if (message.error) {
+                log(`listDir error: ${message.error}`);
+            }
+        }
+
+        function joinPath(dir, name) {
+            if (!dir) return name;
+            if (dir.endsWith('/') || dir.endsWith('\\')) return dir + name;
+            return dir + SEP + name;
+        }
+
+        function parentDir(p) {
+            // returns parent path using the last separator found
+            const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+            if (idx <= 0) return p.startsWith('/') ? '/' : '~';
+            return p.slice(0, idx);
+        }
+
+        function splitPathForAutocomplete(value) {
+            // returns {dir, prefix}; dir is what we list, prefix is what we filter on
+            if (!value) return { dir: '~', prefix: '' };
+            const v = value.trim();
+            const idx = Math.max(v.lastIndexOf('/'), v.lastIndexOf('\\'));
+            if (idx === -1) return { dir: '~', prefix: v };
+            return { dir: v.slice(0, idx), prefix: v.slice(idx + 1) };
+        }
+
+        // ---------------- Autocomplete ----------------
+        let acState = {
+            input: null,
+            reqId: 0,
+            entries: [],
+            active: -1,
+            lastDir: null,
+            debounce: null,
+        };
+        const acDropdown = document.getElementById('acDropdown');
+
+        function initAutocomplete() {
+            ['inputFilename', 'outputFilename'].forEach(id => {
+                const el = document.getElementById(id);
+                el.addEventListener('focus', () => maybeShowAutocomplete(el));
+                el.addEventListener('input', () => {
+                    clearTimeout(acState.debounce);
+                    acState.debounce = setTimeout(() => maybeShowAutocomplete(el), 150);
+                });
+                el.addEventListener('keydown', e => onAutocompleteKeydown(e));
+                el.addEventListener('blur', () => {
+                    // delay so click on a suggestion registers
+                    setTimeout(hideAutocomplete, 200);
+                });
+            });
+            document.addEventListener('scroll', hideAutocomplete, true);
+            window.addEventListener('resize', hideAutocomplete);
+        }
+
+        async function maybeShowAutocomplete(inputEl) {
+            acState.input = inputEl;
+            const { dir, prefix } = splitPathForAutocomplete(inputEl.value);
+            if (acState.lastDir !== dir) {
+                acState.lastDir = dir;
+                acState.entries = [];
+                try {
+                    const resp = await requestListDir(inputEl.id, dir, pickerShowHidden());
+                    acState.entries = resp.entries || [];
+                } catch (e) {
+                    hideAutocomplete();
+                    return;
+                }
+            }
+            renderAutocomplete(prefix, inputEl);
+        }
+
+        function renderAutocomplete(prefix, inputEl) {
+            const filtered = acState.entries.filter(e =>
+                e.name.toLowerCase().startsWith(prefix.toLowerCase())
+            );
+            if (!filtered.length) {
+                hideAutocomplete();
+                return;
+            }
+            acState.active = -1;
+            acDropdown.innerHTML = '';
+            filtered.slice(0, 200).forEach((e, i) => {
+                const li = document.createElement('li');
+                li.className = e.isDir ? 'dir' : '';
+                li.textContent = (e.isDir ? '\uD83D\uDCC1 ' : '\uD83D\uDCC4 ') + e.name;
+                li.dataset.idx = i;
+                li.addEventListener('mousedown', ev => {
+                    ev.preventDefault();
+                    acceptAutocomplete(filtered[i]);
+                });
+                acDropdown.appendChild(li);
+            });
+            acState.filtered = filtered;
+            positionAutocomplete(inputEl);
+            acDropdown.classList.remove('hidden');
+        }
+
+        function positionAutocomplete(inputEl) {
+            const r = inputEl.getBoundingClientRect();
+            acDropdown.style.top = (window.scrollY + r.bottom + 2) + 'px';
+            acDropdown.style.left = (window.scrollX + r.left) + 'px';
+            acDropdown.style.minWidth = r.width + 'px';
+        }
+
+        function hideAutocomplete() {
+            acDropdown.classList.add('hidden');
+            acDropdown.innerHTML = '';
+            acState.active = -1;
+        }
+
+        function acceptAutocomplete(entry) {
+            const inputEl = acState.input;
+            if (!inputEl) return;
+            const { dir } = splitPathForAutocomplete(inputEl.value);
+            const newPath = joinPath(dir, entry.name);
+            inputEl.value = entry.isDir ? newPath + SEP : newPath;
+            inputEl.dispatchEvent(new Event('input'));
+            if (entry.isDir) {
+                // descend: refresh listing for the new dir
+                acState.lastDir = null;
+                maybeShowAutocomplete(inputEl);
+            } else {
+                hideAutocomplete();
+                inputEl.focus();
+            }
+        }
+
+        function onAutocompleteKeydown(e) {
+            if (acDropdown.classList.contains('hidden')) return;
+            const list = acState.filtered;
+            if (!list || !list.length) return;
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                acState.active = (acState.active + 1) % Math.min(list.length, 200);
+                updateAcActive();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                acState.active = (acState.active - 1 + Math.min(list.length, 200)) % Math.min(list.length, 200);
+                updateAcActive();
+            } else if (e.key === 'Enter' || e.key === 'Tab') {
+                if (acState.active >= 0) {
+                    e.preventDefault();
+                    acceptAutocomplete(list[acState.active]);
+                }
+            } else if (e.key === 'Escape') {
+                hideAutocomplete();
+            }
+        }
+
+        function updateAcActive() {
+            [...acDropdown.children].forEach((li, i) => {
+                li.classList.toggle('ac-active', i === acState.active);
+                if (i === acState.active) li.scrollIntoView({ block: 'nearest' });
+            });
+        }
+
+        // ---------------- Modal picker ----------------
+        const pickerDialog = document.getElementById('filePicker');
+        const pickerList = document.getElementById('pickerList');
+        const pickerPath = document.getElementById('pickerPath');
+        const pickerFilter = document.getElementById('pickerFilter');
+        const pickerNameRow = document.getElementById('pickerNameRow');
+        const pickerName = document.getElementById('pickerName');
+        const pickerTitle = document.getElementById('pickerTitle');
+        const pickerHidden = document.getElementById('pickerHidden');
+        const pickerTruncated = document.getElementById('pickerTruncated');
+        let pickerState = {
+            target: null,    // input id
+            mode: 'open',    // 'open' or 'save'
+            currentDir: '~',
+            entries: [],
+            selectedFile: null,
+        };
+
+        function pickerShowHidden() {
+            return localStorage.getItem(KEY_PICKER_HIDDEN) === '1';
+        }
+
+        function initFilePicker() {
+            pickerHidden.checked = pickerShowHidden();
+            pickerHidden.addEventListener('change', () => {
+                localStorage.setItem(KEY_PICKER_HIDDEN, pickerHidden.checked ? '1' : '0');
+                navigatePicker(pickerState.currentDir);
+            });
+            document.querySelectorAll('.picker-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    openPicker(btn.dataset.target, btn.dataset.mode);
+                });
+            });
+            document.getElementById('pickerUp').addEventListener('click', () => {
+                navigatePicker(parentDir(pickerState.currentDir));
+            });
+            document.getElementById('pickerGo').addEventListener('click', () => {
+                navigatePicker(pickerPath.value || '~');
+            });
+            pickerPath.addEventListener('keydown', e => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    navigatePicker(pickerPath.value || '~');
+                }
+            });
+            pickerFilter.addEventListener('input', () => renderPickerEntries());
+            pickerName.addEventListener('input', () => {
+                pickerState.selectedFile = pickerName.value;
+            });
+            pickerName.addEventListener('keydown', e => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    confirmPicker();
+                }
+            });
+            document.getElementById('pickerCancel').addEventListener('click', closePicker);
+            document.getElementById('pickerChoose').addEventListener('click', confirmPicker);
+            pickerDialog.addEventListener('close', () => {
+                if (pickerDialog.returnValue === 'choose') return;
+            });
+        }
+
+        function openPicker(targetId, mode) {
+            pickerState.target = targetId;
+            pickerState.mode = mode;
+            pickerTitle.textContent = mode === 'save' ? 'Save to...' : 'Open file...';
+            pickerNameRow.classList.toggle('hidden', mode !== 'save');
+            const current = document.getElementById(targetId).value;
+            let startDir = localStorage.getItem(KEY_PICKER_LASTDIR) || '~';
+            if (current) {
+                const { dir } = splitPathForAutocomplete(current);
+                startDir = dir || startDir;
+            }
+            pickerName.value = mode === 'save' ? (current ? current.split(/[\\/]/).pop() : '') : '';
+            pickerFilter.value = '';
+            pickerDialog.showModal();
+            navigatePicker(startDir);
+        }
+
+        function closePicker() {
+            pickerDialog.close();
+        }
+
+        async function navigatePicker(path) {
+            pickerState.currentDir = path;
+            pickerPath.value = path;
+            pickerList.innerHTML = '';
+            pickerTruncated.classList.add('hidden');
+            try {
+                const resp = await requestListDir(pickerState.target, path, pickerHidden.checked);
+                pickerState.entries = resp.entries || [];
+                pickerState.currentDir = resp.path || path;
+                pickerPath.value = pickerState.currentDir;
+                if (resp.selected) {
+                    pickerState.selectedFile = resp.selected;
+                    if (pickerState.mode === 'save') pickerName.value = resp.selected;
+                }
+                if (resp.truncated) {
+                    pickerTruncated.textContent = `Listing truncated at ${resp.entries.length} entries. Use the filter box to narrow down.`;
+                    pickerTruncated.classList.remove('hidden');
+                }
+                renderPickerEntries();
+            } catch (e) {
+                const li = document.createElement('li');
+                li.textContent = '\u26A0 ' + e.message;
+                li.style.color = 'var(--pico-primary)';
+                pickerList.appendChild(li);
+            }
+        }
+
+        function renderPickerEntries() {
+            const q = (pickerFilter.value || '').toLowerCase();
+            pickerList.innerHTML = '';
+            const entries = pickerState.entries.filter(e =>
+                !q || e.name.toLowerCase().includes(q)
+            );
+            entries.slice(0, 1000).forEach(e => {
+                const li = document.createElement('li');
+                li.className = (e.isDir ? 'dir' : '') +
+                    (e.name === pickerState.selectedFile ? ' selected' : '');
+                li.textContent = (e.isDir ? '\uD83D\uDCC1 ' : '\uD83D\uDCC4 ') + e.name;
+                li.addEventListener('click', () => onPickerRowClick(e));
+                li.addEventListener('dblclick', () => onPickerRowDblClick(e));
+                pickerList.appendChild(li);
+            });
+        }
+
+        function onPickerRowClick(entry) {
+            if (entry.isDir) return; // single click on dir does nothing, dblclick descends
+            pickerState.selectedFile = entry.name;
+            if (pickerState.mode === 'save') {
+                pickerName.value = entry.name;
+            }
+            renderPickerEntries();
+        }
+
+        function onPickerRowDblClick(entry) {
+            if (entry.isDir) {
+                navigatePicker(joinPath(pickerState.currentDir, entry.name));
+            } else if (pickerState.mode === 'open') {
+                commitPicked(joinPath(pickerState.currentDir, entry.name));
+            } else {
+                pickerName.value = entry.name;
+                pickerState.selectedFile = entry.name;
+                renderPickerEntries();
+            }
+        }
+
+        function confirmPicker() {
+            if (pickerState.mode === 'save') {
+                const name = (pickerName.value || '').trim();
+                if (!name) {
+                    pickerName.focus();
+                    return;
+                }
+                const full = joinPath(pickerState.currentDir, name);
+                const existing = pickerState.entries.find(e => e.name === name && !e.isDir);
+                if (existing && !confirm(`File exists: ${full}\nOverwrite?`)) {
+                    return;
+                }
+                commitPicked(full);
+            } else {
+                if (!pickerState.selectedFile) {
+                    if (pickerState.entries.length === 1 && !pickerState.entries[0].isDir) {
+                        pickerState.selectedFile = pickerState.entries[0].name;
+                    } else {
+                        pickerList.focus();
+                        return;
+                    }
+                }
+                commitPicked(joinPath(pickerState.currentDir, pickerState.selectedFile));
+            }
+        }
+
+        function commitPicked(fullPath) {
+            const input = document.getElementById(pickerState.target);
+            input.value = fullPath;
+            input.dispatchEvent(new Event('input'));
+            localStorage.setItem(KEY_PICKER_LASTDIR, pickerState.currentDir);
+            pickerDialog.close('choose');
+            hideAutocomplete();
+        }
     </script>
 </body>
 

--- a/pyglossary/ui/ui_web/websocket_main.py
+++ b/pyglossary/ui/ui_web/websocket_main.py
@@ -197,8 +197,8 @@ def handle_list_dir_request(
 	server: ServerType,
 	message: str,
 ) -> None:
-	log.debug(f"processing listDir request from client #{client.get('id')}")
 	params = json.loads(message)
+	log.debug(f"listDir #{client.get('id')}: {params.get('target')}={params.get('path')}")
 	req_id = params.get("reqId")
 	target = params.get("target")  # which input this listing is for
 	raw_path = params.get("path") or "~"

--- a/pyglossary/ui/ui_web/websocket_main.py
+++ b/pyglossary/ui/ui_web/websocket_main.py
@@ -50,6 +50,7 @@ __all__ = ["create_server"]
 
 MAX_IMAGE_SIZE = 512000
 DEFAULT_MAX_BROWSE_ENTRIES = 42
+MAX_LISTDIR_ENTRIES = 2000
 
 
 log = logging.getLogger("pyglossary.web.server")
@@ -80,6 +81,12 @@ def message_received(client: dict[str, Any], server: ServerType, message: str) -
 	if message == "ping":
 		print(f"Client({client.get('id')}) said: {message}")
 		server.send_message_to_all({"type": "info", "text": "ws: pong ✔️"})
+
+	elif "listDir" in message:
+		try:
+			handle_list_dir_request(client, server, message)
+		except Exception as e:
+			log.error(f"{e!s} handling listDir request {client}")
 
 	elif "browse" in message:
 		try:
@@ -183,6 +190,115 @@ def handle_browse_request(
 			)
 		if num_results >= max_results:
 			break
+
+
+def handle_list_dir_request(
+	client: dict[str, Any],
+	server: ServerType,
+	message: str,
+) -> None:
+	params = json.loads(message)
+	req_id = params.get("reqId")
+	target = params.get("target")  # which input this listing is for
+	raw_path = params.get("path") or "~"
+	show_hidden = bool(params.get("showHidden", False))
+
+	try:
+		resolved = Path(raw_path).expanduser()
+	except (ValueError, OSError) as e:
+		server.send_message_to_all(
+			{
+				"type": "listDir",
+				"reqId": req_id,
+				"target": target,
+				"error": f"invalid path: {e!s}",
+			}
+		)
+		return
+
+	# If the path points to a file, list its parent and mark the file selected.
+	selected_name = None
+	if resolved.is_file():
+		selected_name = resolved.name
+		resolved = resolved.parent
+
+	if not resolved.exists():
+		server.send_message_to_all(
+			{
+				"type": "listDir",
+				"reqId": req_id,
+				"target": target,
+				"error": f"path does not exist: {resolved}",
+			}
+		)
+		return
+
+	if not resolved.is_dir():
+		server.send_message_to_all(
+			{
+				"type": "listDir",
+				"reqId": req_id,
+				"target": target,
+				"error": f"not a directory: {resolved}",
+			}
+		)
+		return
+
+	entries = []
+	truncated = False
+	try:
+		for child in resolved.iterdir():
+			name = child.name
+			if not show_hidden and name.startswith("."):
+				continue
+			try:
+				is_dir = child.is_dir()
+			except OSError:
+				is_dir = False
+			try:
+				stat = child.stat()
+				size = stat.st_size
+				mtime = stat.st_mtime
+			except OSError:
+				size = None
+				mtime = None
+			entries.append(
+				{
+					"name": name,
+					"isDir": is_dir,
+					"size": size,
+					"mtime": mtime,
+				}
+			)
+			if len(entries) >= MAX_LISTDIR_ENTRIES:
+				truncated = True
+				break
+	except PermissionError as e:
+		server.send_message_to_all(
+			{
+				"type": "listDir",
+				"reqId": req_id,
+				"target": target,
+				"error": f"permission denied: {e!s}",
+				"path": str(resolved),
+			}
+		)
+		return
+
+	# Sort: directories first, then by name (case-insensitive)
+	entries.sort(key=lambda e: (not e["isDir"], e["name"].lower()))
+
+	server.send_message_to_all(
+		{
+			"type": "listDir",
+			"reqId": req_id,
+			"target": target,
+			"path": str(resolved),
+			"entries": entries,
+			"selected": selected_name,
+			"truncated": truncated,
+		}
+	)
 
 
 def create_server(host: str, port: int) -> HttpWebsocketServer:

--- a/pyglossary/ui/ui_web/websocket_main.py
+++ b/pyglossary/ui/ui_web/websocket_main.py
@@ -197,6 +197,7 @@ def handle_list_dir_request(
 	server: ServerType,
 	message: str,
 ) -> None:
+	log.debug(f"processing listDir request from client #{client.get('id')}")
 	params = json.loads(message)
 	req_id = params.get("reqId")
 	target = params.get("target")  # which input this listing is for

--- a/pyglossary/ui/ui_web/websocket_main.py
+++ b/pyglossary/ui/ui_web/websocket_main.py
@@ -135,7 +135,7 @@ def handle_browse_request(
 	log.debug(f"processing client #{client} message")
 	params = json.loads(message)
 	wordQuery = params.get("word")
-	glossary_path = params.get("path")
+	glossary_path = os.path.expanduser(params.get("path"))
 	glossary_format = params.get("format")
 	max_results = int(params.get("max", DEFAULT_MAX_BROWSE_ENTRIES))
 
@@ -183,7 +183,7 @@ def handle_browse_request(
 			server.send_message_to_all(
 				{
 					"type": "browse",
-					"data": f"<hr>Total: {num_results}",
+					"data": f"<hr>{num_results}",
 					"num": num_results,
 					"max": max_results,
 				}

--- a/scripts/ci/collect-coverage.sh
+++ b/scripts/ci/collect-coverage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-rootDir=$(dirname $(dirname $(realpath $(dirname "$0"))))
+rootDir=$(git rev-parse --show-toplevel)
 artifactDir="$rootDir/artifacts/coverage"
 mkdir -p "$artifactDir"
 

--- a/scripts/ci/coverage-pr-comment.py
+++ b/scripts/ci/coverage-pr-comment.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 
 def repo_root() -> Path:
-	return Path(__file__).resolve().parents[2]
+	myDir = Path(__file__).resolve()
+	assert len(myDir.parents) > 3, f"{myDir=}"
+	return myDir.parents[2]
 
 
 def run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:


### PR DESCRIPTION
### Problem description
The current Web UI requires user to enter the full path to input and output files, basically just pasting it from somewhere, which is clunky and not easy to use.

### Solution
A. Provide path auto-suggest when user starts typing in the inputs
B. Add a 📁 Browse button that mimics a desktop-style file picker. 

### Changes
- add js and ws://listDir hooks for directory/file path autosuggest on user input
- add 📁 browse buttons for ws://listDir
- (cleanup) browse.html: replace hard-coded format list with existing /config endpoint