### PR TITLE
doc/lzo.md: replace broken link for python-lzo Windows installation

### DIFF
--- a/doc/lzo.md
+++ b/doc/lzo.md
@@ -12,7 +12,7 @@
 
 - **On Windows**:
 
-  - Open this page: https://www.lfd.uci.edu/~gohlke/pythonlibs/#python-lzo
+  - Open this page: https://github.com/ilius/python-lzo/releases
   - If you are using Python 3.7 (32 bit) for example, click on `python_lzo‑1.12‑cp37‑cp37m‑win32.whl`
   - Open Start -> type Command -> right-click on Command Prompt -> Run as administrator
-  - Run `pip install C:\....\python_lzo‑1.12‑cp37‑cp37m‑win32.whl` command, giving the path of downloaded file
+  - Run `pip install C:\....\python_lzo‑1.12‑cp37‑cp37m‑win32.whl` command, giving the path of downloaded file, or, alternatively, pass the URL to the .whl, e.g. for Python 3.13 `pip install https://github.com/ilius/python-lzo/releases/download/v1.16/python_lzo-1.16-cp313-cp313-win_amd64.whl` 


### PR DESCRIPTION
- replace URL to old broken python-lzo with maintained version 
- provide pip example with direct URL to .whl