### PR TITLE
feat(mobi): allow to pass custom arguments to kindlegen

### DIFF
--- a/doc/p/mobi.md
+++ b/doc/p/mobi.md
@@ -31,6 +31,7 @@ To update, modify plugins/mobi/__init__.py file, then run ./scripts/gen
 | css |  | str | Path to css file |
 | cover_path |  | str | Path to cover file |
 | kindlegen_path |  | str | Path to kindlegen executable |
+| kindlegen_args | `None` | list | Additional arguments forwarded to kindlegen |
 | file_size_approx | `271360` | int | Approximate size of each xhtml file (example: 200kb) |
 | hide_word_index | `False` | bool | Hide headword in tap-to-check interface |
 | spellcheck | `True` | bool | Enable wildcard search and spell correction during word lookup |

--- a/plugins-meta/index.json
+++ b/plugins-meta/index.json
@@ -852,6 +852,11 @@
 				"customValue": true,
 				"comment": "Path to kindlegen executable"
 			},
+			"kindlegen_args": {
+				"class": "ListOption",
+				"type": "list",
+				"comment": "Additional arguments forwarded to kindlegen"
+			},
 			"compress": {
 				"class": "BoolOption",
 				"type": "bool",
@@ -913,6 +918,7 @@
 			"css": "",
 			"cover_path": "",
 			"kindlegen_path": "",
+			"kindlegen_args": null,
 			"file_size_approx": 271360,
 			"hide_word_index": false,
 			"spellcheck": true,

--- a/pyglossary/plugins/ebook_mobi/__init__.py
+++ b/pyglossary/plugins/ebook_mobi/__init__.py
@@ -9,6 +9,7 @@ from pyglossary.option import (
 	BoolOption,
 	FileSizeOption,
 	IntOption,
+	ListOption,
 	StrOption,
 )
 
@@ -57,6 +58,9 @@ optionsProp: dict[str, Option] = {
 	# specific to mobi
 	"kindlegen_path": StrOption(
 		comment="Path to kindlegen executable",
+	),
+	"kindlegen_args": ListOption(
+		comment="Additional arguments forwarded to kindlegen",
 	),
 	"compress": BoolOption(
 		disabled=True,

--- a/pyglossary/plugins/ebook_mobi/writer.py
+++ b/pyglossary/plugins/ebook_mobi/writer.py
@@ -61,6 +61,7 @@ class Writer(EbookWriter):
 	_compress: bool = False
 	_keep: bool = False
 	_kindlegen_path: str = ""
+	_kindlegen_args: list | None = None
 	_file_size_approx: int = 271360
 	_hide_word_index: bool = False
 	_spellcheck: bool = True
@@ -296,15 +297,19 @@ xmlns:oebpackage="http://openebook.org/namespaces/oeb-package/1.0/">
 		# name = self._glos.getInfo("name")
 		log.info(f"Creating .mobi file with kindlegen, using {kindlegen_path!r}")
 		direc, filename = split(filename)
+
+		kindlegen_args = self._kindlegen_args or []
+		kindlegen_args.extend(["-gen_ff_mobi7", "-dont_append_source"])
+		if isDebug():
+			kindlegen_args.append("-verbose")
+		kindlegen_args.extend(["-o", "content.mobi"])
+		log.info(f"Effective kindlegen arguments: {' '.join(kindlegen_args)}")
+
 		cmd = [
 			kindlegen_path,
 			join(filename, "OEBPS", "content.opf"),
-			"-gen_ff_mobi7",
-			"-dont_append_source",
+			*kindlegen_args,
 		]
-		if isDebug():
-			cmd.append("-verbose")
-		cmd += ["-o", "content.mobi"]
 		proc = subprocess.Popen(
 			cmd,
 			cwd=direc,


### PR DESCRIPTION
This patch keeps the current behavior and add the capability to pass custom arguments to kindlegen.

Benefits:
- It allows to pass `-verbose` in non-debug runs (I wanted that without having to be flooded by DEBUG logs).
- It allows to switch to [Kindling](https://github.com/ciscoriordan/kindling/) without changing anything more on your side.

Changes tested locally with success.