### PR TITLE
slob: add audio format support for m4a, m4b, aac, webm

### DIFF
--- a/pyglossary/plugins/aard2_slob/writer.py
+++ b/pyglossary/plugins/aard2_slob/writer.py
@@ -70,6 +70,11 @@ class Writer:
 		"spx": "audio/x-speex",
 		"wav": "audio/wav",
 		"mp4": "video/mp4",
+		"m4a": "audio/mp4",
+		"m4b": "audio/mp4",
+		"aac": "audio/aac",
+		"webm": "audio/webm",
+		"weba": "audio/webm",
 	}
 
 	def __init__(self, glos: WriterGlossaryType) -> None:


### PR DESCRIPTION
whitelist mime types: m4a, m4b, aac, webm, weba