### PR TITLE
feat(plugins): add support for custom Pocketbook metadata

### DIFF
--- a/doc/p/pocketbook_sdic.md
+++ b/doc/p/pocketbook_sdic.md
@@ -26,8 +26,9 @@ To update, modify plugins/pocketbook_sdic/__init__.py file, then run ./scripts/g
 
 | Name | Default | Type | Comment |
 | ---- | ------- | ---- | ------- |
-| metadata_dir |  | str | Path to a directory containing collates.txt, morphems.txt, and keyboard.txt |
+| metadata_dir |  | str | Path to a directory containing collates.txt, morphems.txt, keyboard.txt, and an optional metadata.json |
 | collates_path |  | str | Path to collates.txt (overrides metadata_dir) |
 | keyboard_path |  | str | Path to keyboard.txt (overrides metadata_dir) |
 | morphems_path |  | str | Path to morphems.txt (overrides metadata_dir) |
+| metadata_json_path |  | str | Path to metadata.json (overrides metadata_dir) |
 | merge_separator | `<br>` | str | Separator for merging duplicate headwords |

--- a/plugins-meta/index.json
+++ b/plugins-meta/index.json
@@ -1579,7 +1579,7 @@
 				"class": "StrOption",
 				"type": "str",
 				"customValue": true,
-				"comment": "Path to a directory containing collates.txt, morphems.txt, and keyboard.txt"
+				"comment": "Path to a directory containing collates.txt, morphems.txt, keyboard.txt, and an optional metadata.json"
 			},
 			"collates_path": {
 				"class": "StrOption",
@@ -1599,6 +1599,12 @@
 				"customValue": true,
 				"comment": "Path to morphems.txt (overrides metadata_dir)"
 			},
+			"metadata_json_path": {
+				"class": "StrOption",
+				"type": "str",
+				"customValue": true,
+				"comment": "Path to metadata.json (overrides metadata_dir)"
+			},
 			"merge_separator": {
 				"class": "StrOption",
 				"type": "str",
@@ -1614,6 +1620,7 @@
 			"collates_path": "",
 			"keyboard_path": "",
 			"morphems_path": "",
+			"metadata_json_path": "",
 			"merge_separator": "<br>"
 		}
 	},

--- a/pyglossary/plugins/pocketbook_sdic/__init__.py
+++ b/pyglossary/plugins/pocketbook_sdic/__init__.py
@@ -47,7 +47,8 @@ website = None
 optionsProp: dict[str, Option] = {
 	"metadata_dir": StrOption(
 		comment="Path to a directory containing collates.txt,"
-		" morphems.txt, and keyboard.txt",
+		" morphems.txt, keyboard.txt, and an optional"
+		" metadata.json",
 	),
 	"collates_path": StrOption(
 		comment="Path to collates.txt (overrides metadata_dir)",
@@ -57,6 +58,9 @@ optionsProp: dict[str, Option] = {
 	),
 	"morphems_path": StrOption(
 		comment="Path to morphems.txt (overrides metadata_dir)",
+	),
+	"metadata_json_path": StrOption(
+		comment="Path to metadata.json (overrides metadata_dir)",
 	),
 	"merge_separator": StrOption(
 		comment="Separator for merging duplicate headwords",

--- a/pyglossary/plugins/pocketbook_sdic/writer.py
+++ b/pyglossary/plugins/pocketbook_sdic/writer.py
@@ -6,6 +6,7 @@ Packages sorted glossary entries into PocketBook SDIC format for e-ink devices.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import struct
@@ -37,6 +38,7 @@ __all__ = [
 	"_pack_blocks",
 	"_prepare_collate_section",
 	"_prepare_keyboard_section",
+	"_prepare_metadata_section",
 	"_prepare_morphems_section",
 	"_prepare_section_compressed",
 	"_prepare_sparse_index_section",
@@ -240,6 +242,29 @@ def _prepare_keyboard_section(keyboard: str) -> bytes:
 	return _prepare_section_compressed(keyboard.encode("utf-8"))
 
 
+def _prepare_metadata_section(meta: str) -> bytes:
+	"""
+	Build the optional JSON metadata section: [uint32 size][json bytes].
+
+	Ensures all nine keys required by libdictionary.so are present.
+	"""
+	data = json.loads(meta)
+	full_meta = {
+		"version": int(data.get("version") or 0),
+		"specialProject": int(data.get("specialProject") or 0),
+		"name": str(data.get("name") or ""),
+		"localeFrom": str(data.get("localeFrom") or ""),
+		"localeTo": str(data.get("localeTo") or ""),
+		"description": str(data.get("description") or ""),
+		"category": str(data.get("category") or ""),
+		"provider": str(data.get("provider") or ""),
+		"set": str(data.get("set") or ""),
+	}
+
+	json_bytes = json.dumps(full_meta, indent=2, ensure_ascii=False).encode("utf-8")
+	return struct.pack("<I", len(json_bytes)) + json_bytes
+
+
 def _prepare_sparse_index_section(sparse_index: bytes) -> bytes:
 	"""
 	Build the sparse index section (zlib-compressed).
@@ -256,6 +281,7 @@ def _build_header(
 	max_entry_size: int,
 	name: str,
 	section_sizes: list[int],
+	metadata_len: int = 0,
 ) -> bytes:
 	"""Build the 128-byte SDIC header."""
 	header = bytearray(HEADER_SIZE)
@@ -267,10 +293,15 @@ def _build_header(
 	struct.pack_into("<I", header, 0x08, entry_count)
 	# MaxEntrySize (0x0C)
 	struct.pack_into("<I", header, 0x0C, max(DEFAULT_MAX_ENTRY_SIZE, max_entry_size))
-	# Reserved1 (0x10-0x23) stays zero — no encryption, no metadata
+	# Reserved1 (0x10-0x1B) stays zero — padding
+	# EncryptionSeed (0x1C) stays zero
 
 	# Section offsets
 	offset = HEADER_SIZE
+	if metadata_len > 0:
+		# MetadataOffset (0x20)
+		struct.pack_into("<I", header, 0x20, offset)
+		offset += metadata_len
 	# CollateOffset (0x24)
 	struct.pack_into("<I", header, 0x24, offset)
 	offset += section_sizes[0]
@@ -298,8 +329,8 @@ def _resolve_metadata_file(
 	explicit_path: str | None,
 	metadata_dir: str | None,
 	filename: str,
-	defaults_dir: str,
-) -> str:
+	defaults_dir: str | None,
+) -> str | None:
 	"""Resolve a metadata file path using the fallback chain."""
 	if explicit_path:
 		if not os.path.isfile(explicit_path):
@@ -311,10 +342,13 @@ def _resolve_metadata_file(
 		path = os.path.join(metadata_dir, filename)
 		if os.path.isfile(path):
 			return path
+		if defaults_dir is None:
+			return None
 		raise FileNotFoundError(
 			f"{filename} not found in metadata_dir: {metadata_dir}",
 		)
-	# Built-in defaults
+	if defaults_dir is None:
+		return None
 	return os.path.join(defaults_dir, filename)
 
 
@@ -325,6 +359,7 @@ class Writer:
 	_collates_path: str = ""
 	_keyboard_path: str = ""
 	_morphems_path: str = ""
+	_metadata_json_path: str = ""
 	_merge_separator: str = "<br>"
 
 	def __init__(self, glos: WriterGlossaryType) -> None:
@@ -337,7 +372,7 @@ class Writer:
 	def finish(self) -> None:
 		self._filename = ""
 
-	def write(self) -> Generator[None, EntryType, None]:
+	def write(self) -> Generator[None, EntryType, None]:  # noqa: PLR0912
 		defaults_dir = os.path.join(
 			os.path.dirname(__file__),
 			"defaults",
@@ -361,12 +396,23 @@ class Writer:
 			"keyboard.txt",
 			defaults_dir,
 		)
+		metadata_json_path = _resolve_metadata_file(
+			self._metadata_json_path or None,
+			metadata_dir,
+			"metadata.json",
+			None,
+		)
 
 		collate = load_collates(collates_path)
 		with open(morphems_path, encoding="utf-8") as f:
 			morphems = f.read().strip()
 		with open(keyboard_path, encoding="utf-8") as f:
 			keyboard = f.read().strip()
+
+		metadata_section = b""
+		if metadata_json_path:
+			with open(metadata_json_path, encoding="utf-8") as f:
+				metadata_section = _prepare_metadata_section(f.read())
 
 		# Collect entries
 		entries: list[tuple[str, str]] = []
@@ -406,7 +452,9 @@ class Writer:
 				merged[-1] = (word, merged[-1][1] + sep + defi)
 			else:
 				merged.append((word, defi))
-		entries = merged
+		if len(entries) != len(merged):
+			log.info(f"SDIC: merged {len(entries) - len(merged)} duplicate headwords")
+			entries = merged
 
 		# Encode entries
 		words: list[str] = []
@@ -457,11 +505,14 @@ class Writer:
 			max_entry_size=max_entry_size,
 			name=name,
 			section_sizes=section_sizes,
+			metadata_len=len(metadata_section),
 		)
 
 		# Write the final file
 		with open(self._filename, "wb") as f:
 			f.write(header)
+			if metadata_section:
+				f.write(metadata_section)
 			f.write(collate_section)
 			f.write(morphems_section)
 			f.write(keyboard_section)

--- a/tests/pocketbook_sdic_test.py
+++ b/tests/pocketbook_sdic_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import struct
 import sys
@@ -30,6 +31,7 @@ from pyglossary.plugins.pocketbook_sdic.writer import (
 	_pack_blocks,
 	_prepare_collate_section,
 	_prepare_keyboard_section,
+	_prepare_metadata_section,
 	_prepare_morphems_section,
 	_prepare_section_compressed,
 	_prepare_sparse_index_section,
@@ -390,6 +392,25 @@ class TestPrepareSections(unittest.TestCase):
 		self.assertEqual(len(decompressed), size)
 		self.assertTrue(decompressed.endswith(b"\x00\x00"))
 
+	def test_metadata_section_encoding(self):
+		meta = json.dumps(
+			{
+				"name": "Test Dictionary",
+				"localeFrom": "en",
+				"localeTo": "fr",
+			}
+		)
+		section = _prepare_metadata_section(meta)
+		json_len = struct.unpack_from("<I", section, 0)[0]
+		self.assertEqual(len(section), 4 + json_len)
+		data = json.loads(section[4:].decode("utf-8"))
+		self.assertEqual(data["name"], "Test Dictionary")
+		self.assertEqual(data["localeFrom"], "en")
+		self.assertEqual(data["localeTo"], "fr")
+		self.assertEqual(data["version"], 0)
+		self.assertEqual(data["specialProject"], 0)
+		self.assertEqual(data["description"], "")
+
 
 class TestBuildHeader(unittest.TestCase):
 	"""Test header construction."""
@@ -441,6 +462,23 @@ class TestBuildHeader(unittest.TestCase):
 		self.assertEqual(keyboard_offset, HEADER_SIZE + 300)
 		self.assertEqual(sparse_offset, HEADER_SIZE + 600)
 		self.assertEqual(data_offset, HEADER_SIZE + 1000)
+
+	def test_header_with_metadata_offset(self):
+		metadata_len = 150
+		header = _build_header(
+			entry_count=10,
+			max_entry_size=100,
+			name="Test",
+			section_sizes=[10, 20, 30, 40],
+			metadata_len=metadata_len,
+		)
+		meta_offset = struct.unpack_from("<I", header, 0x20)[0]
+		collate_offset = struct.unpack_from("<I", header, 0x24)[0]
+		morphems_offset = struct.unpack_from("<I", header, 0x28)[0]
+
+		self.assertEqual(meta_offset, HEADER_SIZE)
+		self.assertEqual(collate_offset, HEADER_SIZE + metadata_len)
+		self.assertEqual(morphems_offset, HEADER_SIZE + metadata_len + 10)
 
 	def test_header_name(self):
 		header = _build_header(0, 0, "My Dictionary", [0, 0, 0, 0])


### PR DESCRIPTION
In order to be able to fully use PyGlossary for Pocketbook/Vivlio conversions, this metadata.json stuff is needed. It is now synced with the [original Go code](https://codeberg.org/datyoma/pbdt/commit/7c7489b2e563ec6f1d1002c0be195a150fadde73).
It allows to have proper details about a given dictionary on the device.

There is one thing to note (for future people looking for answers): using a language code that is [not hardcoded on the device](https://codeberg.org/datyoma/pbdt/issues/1) will make the Dictionary app to crash. For instance, setting `localeFrom` or `localeTo` to "la" (for a Latin dictionary) will crash the device. The check is left to the user, since the hardcoded list is changing from firmware versions to Pocketbook models.
