### PR TITLE
README - fix mac install script to work for current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can either download the latest `setup.exe` from [Releases](https://github.co
 If you download the DMG file from [Releases](https://github.com/ilius/pyglossary/releases) and install it, Mac may refuse to run it, showing **the app is damaged and cannot be opened** error. In that case, move the unpacked bundle to `/Applications`, and run this from the Terminal:
 
 ```bash
-/usr/bin/xattr -d com.apple.quarantine /Applications/PyGlossaryWX.app
+/usr/bin/xattr -d com.apple.quarantine /Applications/PyGlossaryTk.app
 ```
 
 Now you should be able to open the app by **right-clicking** on **/Applications/PyGlossary.app** in Finder, selecting **Open** and confirming running an app unsigned by Apple (only needs to be done once).


### PR DESCRIPTION
Hi, since the app was updated to default to PyGlossay**Tk.**app, this needs to be updated here too.

Tested on macos 26.6.2